### PR TITLE
feat(dcp): add ownership verification and release-one adapters

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -31,6 +31,7 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0012 | Public Facade Target Contract Migration | HIGH | Migrate public FastMCP to registry-v2 opaque target_id local evidence tools. **Done** — merged PR #1057. | 0011-REMEDIATION-01 |
 | TP-DCP-MCP-RO-0013 | Connector Policy Schema And Auth Context | HIGH | Strict connector policy schema/loader and provider-neutral sealed auth context with target/tool authorization. **No public ingress.** | 0012 |
 | TP-DCP-MCP-RO-0014 | Loopback Streamable HTTP Ingress | HIGH | Auth-before-discovery loopback HTTP ingress, rate limits, redacted audit, start/stop/health. **No public bind/tunnel.** | 0013 |
+| TP-DCP-MCP-RO-0015 | Ownership Verification And Release-One Adapters | HIGH | Fail-closed ownership verifier + ConPort decision list/read and dope-memory search/replay gates. **No live default network.** | 0014 |
 
 ## Sequencing rationale
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/OWNERSHIP_AND_SAFE_ADAPTERS.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/OWNERSHIP_AND_SAFE_ADAPTERS.md
@@ -1,0 +1,90 @@
+---
+id: dcp-mcp-readonly-ownership-and-safe-adapters
+title: DCP Ownership Verification And Release-One Adapters
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Fail-closed ownership verification and release-one ConPort/dope-memory adapter gates for the DCP read-only facade.
+---
+
+# Ownership Verification And Release-One Adapters
+
+Packet: **TP-DCP-MCP-RO-0015**
+
+## Scope
+
+This packet lands:
+
+1. A pure **ownership verifier** that adjudicates candidate evidence without
+   trusting ports alone.
+2. A **release-one safe adapter gate** for:
+   - ConPort: decision list + decision read by explicit ID
+   - dope-memory: `memory_search` + `memory_replay_session`
+
+It does **not** enable dope-context, task-orchestrator, bridge passthrough,
+progress reads (auto-fork risk), broad ConPort query mode, writes, tunnels, or
+live network by default. Tests inject HTTP transports; live backends remain
+opt-in and unauthorized in this series step.
+
+## Ownership rules
+
+Module: `dcp_facade.ownership`
+
+| Check | Fail-closed outcome |
+| --- | --- |
+| Family not in `{conport, dope_memory}` | BLOCKED |
+| `candidate_count != 1` | no candidate / ambiguous |
+| Stale evidence | BLOCKED |
+| Port listening without identity/labels | **port-only BLOCKED** |
+| Missing required labels | BLOCKED |
+| Project ID / roots / label mismatches | BLOCKED |
+| Mounts omit project/worktree root | BLOCKED |
+| `protocol_ok` not True | BLOCKED (live probe required) |
+
+`OwnershipVerdict.callable` is always `False`. Verification never grants
+callable authority by itself.
+
+Required labels:
+
+- `dopemux.project_id`
+- `dopemux.service`
+- `dopemux.worktree_root`
+
+## Release-one operations
+
+Module: `dcp_facade.safe_adapters` + `route_manifest.RELEASE_ONE_OPERATIONS`
+
+| Family | Allowed ops | Explicitly blocked |
+| --- | --- | --- |
+| conport | `list_decisions`, `get_decision` | progress, broad search/query, writes |
+| dope_memory | `memory_search`, `memory_replay_session` | store/correct/reflect/mark/link |
+
+Each entrypoint:
+
+1. Checks operation is release-one.
+2. Requires `OwnershipVerdict.verified` for the same family.
+3. Invokes the low-level adapter with an injected `ReadOnlyHttpClient`.
+4. Returns a non-callable public dict (`callable: false`).
+
+## Relationship to earlier packets
+
+| Packet | Role |
+| --- | --- |
+| 0011 | Runtime/catalog join evidence (non-callable) |
+| 0012 | Public target_id tools (local only) |
+| 0013 | Connector auth/policy |
+| 0014 | Loopback ingress |
+| **0015** | Ownership + release-one adapter gates |
+
+Public FastMCP server tools for live decision/memory reads remain a later
+wiring decision; this packet provides the fail-closed gate those tools must use.
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ownership.py services/dcp-readonly-facade/tests/test_safe_adapters.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+```

--- a/proof/TP-DCP-MCP-RO-0015/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0015/AGY_AUDIT.md
@@ -1,0 +1,19 @@
+# AGY Audit: TP-DCP-MCP-RO-0015
+
+## Provenance
+
+- Auditor: AGY / Google Antigravity CLI (local advisory)
+- Verdict: `NOT_RUN` (AGY invocation timed out locally)
+- Manual local review substitute: PASS_WITH_RISKS for residual live-probe gap
+
+## Expected controls reviewed
+
+- Port-only ownership rejection
+- Release-one operation allowlist (decisions + memory search/replay only)
+- Progress/writes denied without HTTP
+- Ownership never sets callable true
+- No live network in unit tests
+
+## Boundary
+
+Advisory only. Does not satisfy `embedded-audit.yml`.

--- a/proof/TP-DCP-MCP-RO-0015/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0015/AUDITOR_REPORT.md
@@ -1,0 +1,16 @@
+# TP-DCP-MCP-RO-0015 Auditor Report
+
+## Verdict
+
+`SKIPPED` for trusted embedded-audit. Local-only direction; AGY is advisory.
+
+## Local Evidence
+
+- Ownership matrix tests passed
+- Safe adapter gate tests passed
+- Full facade suite passed (opt-in live skipped)
+- Packet schema + pre-commit on allowlist
+
+## Boundary
+
+Merge readiness and PR Steward not claimed.

--- a/proof/TP-DCP-MCP-RO-0015/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0015/COMMAND_LOG.md
@@ -1,0 +1,18 @@
+# TP-DCP-MCP-RO-0015 Command Log
+
+Branch: `codex/dcp-mcp-ro-0015-ownership-adapters`  
+Base: `origin/main` @ `981967366` (TP-0014 / PR #1060 merged)
+
+| Command | Result |
+| --- | --- |
+| 0014 dependency on main | PASS |
+| 0015 collision search | PASS (none) |
+| focused ownership/safe_adapter tests | PASS (20) |
+| full facade suite | PASS; 1 live skip |
+| compileall / ruff | PASS |
+| packet jsonschema | PASS |
+| pre-commit allowlist | PASS |
+| agy advisory | NOT_RUN (timed out); manual local review PASS_WITH_RISKS residual live-probe gap |
+| Trusted embedded audit | NOT_RUN / not claimed |
+
+No live backend, tunnel, credential, or container operation was run.

--- a/proof/TP-DCP-MCP-RO-0015/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0015/PROOF.json
@@ -110,7 +110,11 @@
   ],
   "rollback": "Revert TP-0015 commits",
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
-  }
+    "number": 1061,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1061",
+    "head_at_creation": "1037730fc99937f2456fd5d0cbb0edfa6f21adc8",
+    "blocker": "Trusted embedded audit SKIPPED; AGY NOT_RUN (timeout); merge readiness not claimed."
+  },
+  "implementation_commit": "1037730fc99937f2456fd5d0cbb0edfa6f21adc8"
 }

--- a/proof/TP-DCP-MCP-RO-0015/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0015/PROOF.json
@@ -1,0 +1,116 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0015",
+  "title": "Ownership Verification And Release-One Adapters",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0015-ownership-adapters",
+  "base_branch": "main",
+  "base_sha": "9819673664cb2eda0736cc7100bb18d68a71902f",
+  "depends_on_verified": {
+    "TP-DCP-MCP-RO-0014": {
+      "pr": 1060,
+      "merge_commit": "9819673664cb2eda0736cc7100bb18d68a71902f",
+      "status": "MERGED"
+    }
+  },
+  "scope": "Fail-closed ownership verification without port-only trust; release-one safe adapters for ConPort decision list/read and dope-memory search/replay. No live network default, tunnels, writes, or non-release families.",
+  "input_package": {
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "authority": "advisory_only"
+  },
+  "files_changed": [
+    "services/dcp-readonly-facade/src/dcp_facade/ownership.py",
+    "services/dcp-readonly-facade/src/dcp_facade/safe_adapters.py",
+    "services/dcp-readonly-facade/src/dcp_facade/conport.py",
+    "services/dcp-readonly-facade/src/dcp_facade/route_manifest.py",
+    "services/dcp-readonly-facade/tests/test_ownership.py",
+    "services/dcp-readonly-facade/tests/test_safe_adapters.py",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/OWNERSHIP_AND_SAFE_ADAPTERS.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0015/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0015/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0015/AGY_AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0015/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "focused ownership/safe_adapter tests",
+        "exit_code": 0,
+        "result": "20 passed"
+      },
+      {
+        "command": "full facade suite",
+        "exit_code": 0,
+        "result": "passed; 1 live skipped"
+      },
+      {
+        "command": "compileall",
+        "exit_code": 0,
+        "result": "ok"
+      },
+      {
+        "command": "packet schema",
+        "exit_code": 0,
+        "result": "valid"
+      },
+      {
+        "command": "pre-commit allowlist",
+        "exit_code": 0,
+        "result": "ok"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Trusted embedded audit / PR Steward",
+        "reason": "local-only; AGY advisory only",
+        "mitigation": "readiness not claimed"
+      },
+      {
+        "command": "Live backend ownership/protocol probes",
+        "reason": "no live backends authorized; evidence injected in unit tests",
+        "mitigation": "protocol_ok required for VERIFIED; fail closed when absent"
+      }
+    ]
+  },
+  "local_agy_review": {
+    "status": "NOT_RUN",
+    "reason": "AGY local invocation timed out; manual source review recorded in AGY_AUDIT.md",
+    "ci_trust_status": "NOT_ACCEPTED"
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0015/AUDITOR_REPORT.md",
+    "findings": [],
+    "skip_reason": "No trusted runner/Claude audit route; AGY is advisory only and does not satisfy embedded-audit.yml.",
+    "fixes_applied": [
+      "Ownership verifier with port-only rejection",
+      "Release-one safe adapter gate for ConPort decisions and dope-memory search/replay",
+      "get_decision by explicit ID",
+      "Release-one route/operation tables"
+    ],
+    "remaining_risks": [
+      "Trusted embedded audit unavailable",
+      "Live protocol probes not executed in this packet",
+      "Public FastMCP tools not yet wired to safe_adapters"
+    ]
+  },
+  "residual_risks": [
+    "Operators must supply protocol evidence before treating ownership as verified in production",
+    "Generated .claude/claude_config.json left unstaged"
+  ],
+  "rollback": "Revert TP-0015 commits",
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
+  }
+}

--- a/services/dcp-readonly-facade/src/dcp_facade/conport.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/conport.py
@@ -31,6 +31,31 @@ def get_decisions(
     )
 
 
+def get_decision(
+    client: ReadOnlyHttpClient,
+    base_url: str,
+    workspace_id: str,
+    decision_id: str,
+) -> HttpResponse:
+    """Read one decision by explicit ID (release-one).
+
+    Rejects path-bearing or empty IDs fail-closed. Progress and broad query
+    modes are intentionally not provided here.
+    """
+    if not isinstance(decision_id, str) or not decision_id.strip():
+        raise ReadOnlyHttpError("decision_id is required")
+    if "/" in decision_id or ".." in decision_id or decision_id.strip() != decision_id:
+        raise ReadOnlyHttpError("invalid decision_id")
+    if "/" in workspace_id or ".." in workspace_id:
+        raise ReadOnlyHttpError("invalid workspace_id (must be a single segment)")
+    safe_id = quote(decision_id, safe="")
+    return client.get(
+        base_url,
+        f"/api/decisions/{safe_id}",
+        {"workspace_id": workspace_id},
+    )
+
+
 def get_progress(
     client: ReadOnlyHttpClient,
     base_url: str,

--- a/services/dcp-readonly-facade/src/dcp_facade/ownership.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/ownership.py
@@ -1,0 +1,228 @@
+"""Live ownership verification for release-one adapters (TP-DCP-MCP-RO-0015).
+
+Port presence alone is never ownership authority. This module corroborates
+identity, labels/mounts, protocol evidence, and candidate uniqueness. It performs
+no network, Docker, or backend I/O — callers supply evidence (including optional
+live probe results) and receive a fail-closed verdict.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+RELEASE_ONE_FAMILIES = frozenset({"conport", "dope_memory"})
+
+# Required Docker/runtime labels for a verified candidate.
+REQUIRED_LABEL_KEYS = (
+    "dopemux.project_id",
+    "dopemux.service",
+    "dopemux.worktree_root",
+)
+
+
+@dataclass(frozen=True)
+class OwnershipEvidence:
+    """Corroborating evidence for one service-family candidate.
+
+    ``has_listening_port`` is an operational hint only and cannot alone verify.
+    ``protocol_ok`` must be an explicit True from a completed probe; None means
+    not probed and fails closed.
+    """
+
+    family: str
+    expected_project_id: str
+    expected_project_root: str
+    expected_worktree_root: str
+    runtime_project_id: Optional[str] = None
+    runtime_project_root: Optional[str] = None
+    runtime_worktree_root: Optional[str] = None
+    labels: Mapping[str, str] = field(default_factory=dict)
+    mounts: Sequence[str] = field(default_factory=tuple)
+    protocol_ok: Optional[bool] = None
+    protocol_name: Optional[str] = None
+    has_listening_port: bool = False
+    candidate_count: int = 0
+    stale: bool = False
+    unlabeled: bool = False
+
+
+@dataclass(frozen=True)
+class OwnershipVerdict:
+    family: str
+    state: str  # VERIFIED | BLOCKED
+    reason: str
+    evidence_codes: tuple[str, ...] = ()
+
+    @property
+    def verified(self) -> bool:
+        return self.state == "VERIFIED"
+
+    @property
+    def callable(self) -> bool:
+        """Ownership verification never by itself makes a backend callable.
+
+        Release-one adapters may proceed only when verified **and** the
+        operation is on the release-one allowlist (see safe_adapters).
+        """
+        return False
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "family": self.family,
+            "state": self.state,
+            "reason": self.reason,
+            "callable": False,
+            "evidence_codes": list(self.evidence_codes),
+        }
+
+
+def _canon(path: Optional[str]) -> Optional[str]:
+    if not path or not isinstance(path, str):
+        return None
+    try:
+        return str(Path(path).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def verify_ownership(evidence: OwnershipEvidence) -> OwnershipVerdict:
+    """Fail-closed ownership adjudication from supplied evidence only."""
+    family = (evidence.family or "").strip()
+    if family not in RELEASE_ONE_FAMILIES:
+        return OwnershipVerdict(
+            family=family or "unknown",
+            state="BLOCKED",
+            reason="service family not in release-one set",
+            evidence_codes=("family_blocked",),
+        )
+
+    if evidence.candidate_count <= 0:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="no matching runtime candidate",
+            evidence_codes=("no_candidate",),
+        )
+
+    if evidence.candidate_count > 1:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="ambiguous runtime candidates",
+            evidence_codes=("ambiguous",),
+        )
+
+    if evidence.stale:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="stale runtime evidence",
+            evidence_codes=("stale",),
+        )
+
+    # Port-only trust is explicitly forbidden even if a socket is listening.
+    has_identity = bool(evidence.runtime_project_id and evidence.runtime_project_root)
+    has_labels = bool(evidence.labels) and not evidence.unlabeled
+    if evidence.has_listening_port and not has_identity and not has_labels:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="port presence is not ownership authority",
+            evidence_codes=("port_only",),
+        )
+
+    if evidence.unlabeled or not evidence.labels:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="candidate unlabeled",
+            evidence_codes=("unlabeled",),
+        )
+
+    missing_labels = [key for key in REQUIRED_LABEL_KEYS if key not in evidence.labels]
+    if missing_labels:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="required ownership labels missing",
+            evidence_codes=("missing_labels",),
+        )
+
+    if evidence.runtime_project_id != evidence.expected_project_id:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="wrong project identity",
+            evidence_codes=("wrong_project",),
+        )
+
+    if evidence.labels.get("dopemux.project_id") != evidence.expected_project_id:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="label project identity mismatch",
+            evidence_codes=("label_project_mismatch",),
+        )
+
+    expected_service = "conport" if family == "conport" else "dope-memory"
+    if evidence.labels.get("dopemux.service") not in {family, expected_service}:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="label service mismatch",
+            evidence_codes=("label_service_mismatch",),
+        )
+
+    exp_proj = _canon(evidence.expected_project_root)
+    exp_wt = _canon(evidence.expected_worktree_root)
+    got_proj = _canon(evidence.runtime_project_root)
+    got_wt = _canon(evidence.runtime_worktree_root)
+    label_wt = _canon(evidence.labels.get("dopemux.worktree_root"))
+
+    if not exp_proj or not exp_wt or got_proj != exp_proj or got_wt != exp_wt:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="project/worktree root mismatch",
+            evidence_codes=("root_mismatch",),
+        )
+
+    if label_wt != exp_wt:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="label worktree root mismatch",
+            evidence_codes=("label_root_mismatch",),
+        )
+
+    if evidence.mounts:
+        mount_canons = {_canon(m) for m in evidence.mounts}
+        if exp_wt not in mount_canons and exp_proj not in mount_canons:
+            return OwnershipVerdict(
+                family=family,
+                state="BLOCKED",
+                reason="required mount missing",
+                evidence_codes=("mount_missing",),
+            )
+
+    if evidence.protocol_ok is not True:
+        return OwnershipVerdict(
+            family=family,
+            state="BLOCKED",
+            reason="live protocol verification required or failed",
+            evidence_codes=("protocol_required",),
+        )
+
+    codes = ["identity", "labels", "protocol"]
+    if evidence.mounts:
+        codes.append("mounts")
+    if evidence.has_listening_port:
+        codes.append("port_hint_only")
+    return OwnershipVerdict(
+        family=family,
+        state="VERIFIED",
+        reason="ownership corroborated",
+        evidence_codes=tuple(codes),
+    )

--- a/services/dcp-readonly-facade/src/dcp_facade/route_manifest.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/route_manifest.py
@@ -15,6 +15,7 @@ DOPE_MEMORY = "dope_memory"
 ALLOWED_ROUTES: dict[str, tuple[tuple[str, str], ...]] = {
     CONPORT: (
         ("GET", "/api/decisions"),
+        ("GET", "/api/decisions/{decision_id}"),
         ("GET", "/api/progress"),
         ("GET", "/api/search/{workspace_id}"),
     ),
@@ -23,6 +24,29 @@ ALLOWED_ROUTES: dict[str, tuple[tuple[str, str], ...]] = {
         ("POST", "/tools/memory_replay_session"),
     ),
 }
+
+# Release-one public surface (TP-0015): ownership-gated ops only.
+# Progress and broad ConPort search remain structurally available to legacy
+# Phase-1 helpers but are NOT release-one operations (progress may auto-fork).
+RELEASE_ONE_OPERATIONS: dict[str, tuple[str, ...]] = {
+    CONPORT: ("list_decisions", "get_decision"),
+    DOPE_MEMORY: ("memory_search", "memory_replay_session"),
+}
+
+RELEASE_ONE_ROUTES: dict[str, tuple[tuple[str, str], ...]] = {
+    CONPORT: (
+        ("GET", "/api/decisions"),
+        ("GET", "/api/decisions/{decision_id}"),
+    ),
+    DOPE_MEMORY: (
+        ("POST", "/tools/memory_search"),
+        ("POST", "/tools/memory_replay_session"),
+    ),
+}
+
+
+def is_release_one_operation(family: str, operation: str) -> bool:
+    return operation in RELEASE_ONE_OPERATIONS.get(family, ())
 
 # Only these POST paths may ever be issued (side-effect-free dope-memory reads).
 DOPE_MEMORY_READ_PATHS = frozenset(
@@ -42,6 +66,20 @@ DENIED_ROUTES: tuple[tuple[str, str], ...] = (
     ("POST", "/tools/memory_mark_issue"),
     ("POST", "/tools/memory_link_resolution"),
     ("GET", "/ddg/decisions"),                  # dopecon-bridge proxy
+)
+
+# Operations explicitly blocked for release-one even if a low-level helper exists.
+RELEASE_ONE_DENIED_OPERATIONS: tuple[str, ...] = (
+    "get_progress",
+    "search_progress",
+    "search",
+    "query",
+    "memory_store",
+    "memory_correct",
+    "memory_generate_reflection",
+    "memory_mark_issue",
+    "memory_link_resolution",
+    "log_decision",
 )
 
 # Token substrings that signal a denied route/operation (used by tests).

--- a/services/dcp-readonly-facade/src/dcp_facade/safe_adapters.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/safe_adapters.py
@@ -1,0 +1,174 @@
+"""Release-one safe adapter gate (TP-DCP-MCP-RO-0015).
+
+Only ConPort decision list/read and dope-memory search/replay may run, and only
+after ownership is VERIFIED. Progress, broad query, writes, and non-release
+families are structurally denied. Callers inject HTTP clients — this module
+does not open sockets by itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from . import conport as conport_adapter
+from . import dope_memory as dope_memory_adapter
+from .http_client import HttpResponse, ReadOnlyHttpClient, ReadOnlyHttpError
+from .ownership import OwnershipVerdict
+from .route_manifest import (
+    CONPORT,
+    DOPE_MEMORY,
+    RELEASE_ONE_OPERATIONS,
+    is_release_one_operation,
+)
+
+
+@dataclass(frozen=True)
+class SafeAdapterResult:
+    allowed: bool
+    operation: str
+    family: str
+    reason: str
+    response: Optional[HttpResponse] = None
+
+    def to_public_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "allowed": self.allowed,
+            "operation": self.operation,
+            "family": self.family,
+            "reason": self.reason,
+            "callable": False,
+        }
+        if self.allowed and self.response is not None:
+            out["status_code"] = self.response.status
+            out["ok"] = self.response.ok
+            # Body remains for tool layer redaction; never invent data on deny.
+            out["data"] = self.response.json if self.response.ok else None
+        else:
+            out["data"] = None
+        return out
+
+
+def _deny(operation: str, family: str, reason: str) -> SafeAdapterResult:
+    return SafeAdapterResult(
+        allowed=False, operation=operation, family=family, reason=reason, response=None
+    )
+
+
+def require_verified_ownership(verdict: OwnershipVerdict, family: str) -> Optional[str]:
+    """Return a block reason or None when ownership permits adapter use."""
+    if verdict.family != family:
+        return "ownership family mismatch"
+    if not verdict.verified:
+        return verdict.reason or "ownership not verified"
+    return None
+
+
+def list_decisions(
+    *,
+    ownership: OwnershipVerdict,
+    client: ReadOnlyHttpClient,
+    base_url: str,
+    workspace_id: str,
+    limit: Optional[int] = None,
+) -> SafeAdapterResult:
+    op = "list_decisions"
+    if not is_release_one_operation(CONPORT, op):
+        return _deny(op, CONPORT, "operation not in release-one allowlist")
+    blocked = require_verified_ownership(ownership, CONPORT)
+    if blocked:
+        return _deny(op, CONPORT, blocked)
+    try:
+        resp = conport_adapter.get_decisions(client, base_url, workspace_id, limit=limit)
+    except ReadOnlyHttpError as exc:
+        return _deny(op, CONPORT, f"adapter error: {exc}")
+    return SafeAdapterResult(
+        allowed=True, operation=op, family=CONPORT, reason="ok", response=resp
+    )
+
+
+def get_decision(
+    *,
+    ownership: OwnershipVerdict,
+    client: ReadOnlyHttpClient,
+    base_url: str,
+    workspace_id: str,
+    decision_id: str,
+) -> SafeAdapterResult:
+    op = "get_decision"
+    if not is_release_one_operation(CONPORT, op):
+        return _deny(op, CONPORT, "operation not in release-one allowlist")
+    blocked = require_verified_ownership(ownership, CONPORT)
+    if blocked:
+        return _deny(op, CONPORT, blocked)
+    try:
+        resp = conport_adapter.get_decision(client, base_url, workspace_id, decision_id)
+    except ReadOnlyHttpError as exc:
+        return _deny(op, CONPORT, f"adapter error: {exc}")
+    return SafeAdapterResult(
+        allowed=True, operation=op, family=CONPORT, reason="ok", response=resp
+    )
+
+
+def memory_search(
+    *,
+    ownership: OwnershipVerdict,
+    client: ReadOnlyHttpClient,
+    base_url: str,
+    workspace_id: str,
+    query: str = "",
+    top_k: int = 3,
+) -> SafeAdapterResult:
+    op = "memory_search"
+    if not is_release_one_operation(DOPE_MEMORY, op):
+        return _deny(op, DOPE_MEMORY, "operation not in release-one allowlist")
+    blocked = require_verified_ownership(ownership, DOPE_MEMORY)
+    if blocked:
+        return _deny(op, DOPE_MEMORY, blocked)
+    try:
+        resp = dope_memory_adapter.memory_search(
+            client, base_url, workspace_id, query=query, top_k=top_k
+        )
+    except ReadOnlyHttpError as exc:
+        return _deny(op, DOPE_MEMORY, f"adapter error: {exc}")
+    return SafeAdapterResult(
+        allowed=True, operation=op, family=DOPE_MEMORY, reason="ok", response=resp
+    )
+
+
+def memory_replay_session(
+    *,
+    ownership: OwnershipVerdict,
+    client: ReadOnlyHttpClient,
+    base_url: str,
+    workspace_id: str,
+    session_id: str,
+    mode: str = "replay_current",
+    top_k: int = 3,
+) -> SafeAdapterResult:
+    op = "memory_replay_session"
+    if not is_release_one_operation(DOPE_MEMORY, op):
+        return _deny(op, DOPE_MEMORY, "operation not in release-one allowlist")
+    blocked = require_verified_ownership(ownership, DOPE_MEMORY)
+    if blocked:
+        return _deny(op, DOPE_MEMORY, blocked)
+    try:
+        resp = dope_memory_adapter.memory_replay_session(
+            client, base_url, workspace_id, session_id, mode=mode, top_k=top_k
+        )
+    except ReadOnlyHttpError as exc:
+        return _deny(op, DOPE_MEMORY, f"adapter error: {exc}")
+    return SafeAdapterResult(
+        allowed=True, operation=op, family=DOPE_MEMORY, reason="ok", response=resp
+    )
+
+
+def deny_blocked_operation(operation: str, family: str) -> SafeAdapterResult:
+    """Explicit deny for progress/query/writes and other non-release ops."""
+    if is_release_one_operation(family, operation):
+        return _deny(operation, family, "use the typed release-one entrypoint")
+    return _deny(operation, family, "operation blocked for release-one")
+
+
+def release_one_operations() -> dict[str, tuple[str, ...]]:
+    return {family: tuple(ops) for family, ops in RELEASE_ONE_OPERATIONS.items()}

--- a/services/dcp-readonly-facade/tests/test_ownership.py
+++ b/services/dcp-readonly-facade/tests/test_ownership.py
@@ -1,0 +1,120 @@
+"""Ownership verification matrix (TP-DCP-MCP-RO-0015)."""
+
+from __future__ import annotations
+
+from dcp_facade.ownership import OwnershipEvidence, verify_ownership
+
+
+def _base(**overrides) -> OwnershipEvidence:
+    data = dict(
+        family="conport",
+        expected_project_id="proj-a",
+        expected_project_root="/tmp/proj-a",
+        expected_worktree_root="/tmp/proj-a/wt",
+        runtime_project_id="proj-a",
+        runtime_project_root="/tmp/proj-a",
+        runtime_worktree_root="/tmp/proj-a/wt",
+        labels={
+            "dopemux.project_id": "proj-a",
+            "dopemux.service": "conport",
+            "dopemux.worktree_root": "/tmp/proj-a/wt",
+        },
+        mounts=("/tmp/proj-a/wt",),
+        protocol_ok=True,
+        protocol_name="mcp",
+        has_listening_port=True,
+        candidate_count=1,
+        stale=False,
+        unlabeled=False,
+    )
+    data.update(overrides)
+    return OwnershipEvidence(**data)
+
+
+def test_verified_happy_path():
+    verdict = verify_ownership(_base())
+    assert verdict.verified is True
+    assert verdict.callable is False
+    assert "identity" in verdict.evidence_codes
+
+
+def test_port_only_is_blocked():
+    verdict = verify_ownership(
+        OwnershipEvidence(
+            family="conport",
+            expected_project_id="proj-a",
+            expected_project_root="/tmp/proj-a",
+            expected_worktree_root="/tmp/proj-a/wt",
+            has_listening_port=True,
+            candidate_count=1,
+        )
+    )
+    assert verdict.verified is False
+    assert "port_only" in verdict.evidence_codes or "unlabeled" in verdict.evidence_codes
+
+
+def test_wrong_project_blocked():
+    verdict = verify_ownership(_base(runtime_project_id="other"))
+    assert verdict.verified is False
+    assert "wrong_project" in verdict.evidence_codes
+
+
+def test_ambiguous_candidates_blocked():
+    verdict = verify_ownership(_base(candidate_count=2))
+    assert verdict.verified is False
+    assert "ambiguous" in verdict.evidence_codes
+
+
+def test_stale_blocked():
+    verdict = verify_ownership(_base(stale=True))
+    assert verdict.verified is False
+    assert "stale" in verdict.evidence_codes
+
+
+def test_unlabeled_blocked():
+    verdict = verify_ownership(_base(labels={}, unlabeled=True))
+    assert verdict.verified is False
+    assert "unlabeled" in verdict.evidence_codes
+
+
+def test_protocol_required():
+    verdict = verify_ownership(_base(protocol_ok=None))
+    assert verdict.verified is False
+    assert "protocol_required" in verdict.evidence_codes
+
+
+def test_protocol_failed():
+    verdict = verify_ownership(_base(protocol_ok=False))
+    assert verdict.verified is False
+
+
+def test_root_mismatch_blocked():
+    verdict = verify_ownership(_base(runtime_worktree_root="/tmp/other"))
+    assert verdict.verified is False
+    assert "root_mismatch" in verdict.evidence_codes
+
+
+def test_mount_missing_blocked():
+    verdict = verify_ownership(_base(mounts=("/tmp/unrelated",)))
+    assert verdict.verified is False
+    assert "mount_missing" in verdict.evidence_codes
+
+
+def test_family_not_release_one():
+    verdict = verify_ownership(_base(family="dope_context"))
+    assert verdict.verified is False
+    assert "family_blocked" in verdict.evidence_codes
+
+
+def test_dope_memory_family_label_alias():
+    verdict = verify_ownership(
+        _base(
+            family="dope_memory",
+            labels={
+                "dopemux.project_id": "proj-a",
+                "dopemux.service": "dope-memory",
+                "dopemux.worktree_root": "/tmp/proj-a/wt",
+            },
+        )
+    )
+    assert verdict.verified is True

--- a/services/dcp-readonly-facade/tests/test_safe_adapters.py
+++ b/services/dcp-readonly-facade/tests/test_safe_adapters.py
@@ -1,0 +1,165 @@
+"""Release-one safe adapter gate tests (TP-DCP-MCP-RO-0015)."""
+
+from __future__ import annotations
+
+from dcp_facade.http_client import HttpResponse, ReadOnlyHttpClient, ReadOnlyHttpError
+from dcp_facade.ownership import OwnershipEvidence, OwnershipVerdict, verify_ownership
+from dcp_facade import safe_adapters as SA
+from dcp_facade.route_manifest import (
+    RELEASE_ONE_DENIED_OPERATIONS,
+    RELEASE_ONE_OPERATIONS,
+    is_release_one_operation,
+)
+
+
+class _FakeTransport:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *, method, url, params, json, timeout):
+        self.calls.append(
+            {"method": method, "url": url, "params": params, "json": json}
+        )
+        return HttpResponse(status=200, json={"ok": True, "url": url}, ok=True)
+
+
+def _verified(family: str = "conport") -> OwnershipVerdict:
+    service = "conport" if family == "conport" else "dope-memory"
+    return verify_ownership(
+        OwnershipEvidence(
+            family=family,
+            expected_project_id="proj-a",
+            expected_project_root="/tmp/proj-a",
+            expected_worktree_root="/tmp/proj-a/wt",
+            runtime_project_id="proj-a",
+            runtime_project_root="/tmp/proj-a",
+            runtime_worktree_root="/tmp/proj-a/wt",
+            labels={
+                "dopemux.project_id": "proj-a",
+                "dopemux.service": service,
+                "dopemux.worktree_root": "/tmp/proj-a/wt",
+            },
+            mounts=("/tmp/proj-a/wt",),
+            protocol_ok=True,
+            candidate_count=1,
+        )
+    )
+
+
+def _blocked() -> OwnershipVerdict:
+    return OwnershipVerdict(
+        family="conport", state="BLOCKED", reason="wrong project identity", evidence_codes=("wrong_project",)
+    )
+
+
+def test_release_one_operation_table():
+    assert is_release_one_operation("conport", "list_decisions")
+    assert is_release_one_operation("conport", "get_decision")
+    assert not is_release_one_operation("conport", "get_progress")
+    assert is_release_one_operation("dope_memory", "memory_search")
+    assert "get_progress" in RELEASE_ONE_DENIED_OPERATIONS
+    assert SA.release_one_operations()["conport"] == RELEASE_ONE_OPERATIONS["conport"]
+
+
+def test_list_decisions_requires_ownership():
+    transport = _FakeTransport()
+    client = ReadOnlyHttpClient(transport=transport)
+    denied = SA.list_decisions(
+        ownership=_blocked(),
+        client=client,
+        base_url="http://127.0.0.1:3004",
+        workspace_id="ws",
+    )
+    assert denied.allowed is False
+    assert transport.calls == []
+
+    allowed = SA.list_decisions(
+        ownership=_verified("conport"),
+        client=client,
+        base_url="http://127.0.0.1:3004",
+        workspace_id="ws",
+        limit=5,
+    )
+    assert allowed.allowed is True
+    assert allowed.response is not None and allowed.response.ok
+    assert transport.calls and transport.calls[0]["method"] == "GET"
+    assert "/api/decisions" in transport.calls[0]["url"]
+
+
+def test_get_decision_by_id():
+    transport = _FakeTransport()
+    client = ReadOnlyHttpClient(transport=transport)
+    result = SA.get_decision(
+        ownership=_verified("conport"),
+        client=client,
+        base_url="http://127.0.0.1:3004",
+        workspace_id="ws",
+        decision_id="dec-1",
+    )
+    assert result.allowed is True
+    assert "/api/decisions/dec-1" in transport.calls[0]["url"]
+
+
+def test_progress_explicitly_blocked():
+    result = SA.deny_blocked_operation("get_progress", "conport")
+    assert result.allowed is False
+    assert "blocked" in result.reason
+
+
+def test_memory_search_and_replay_release_one():
+    transport = _FakeTransport()
+    client = ReadOnlyHttpClient(transport=transport)
+    own = _verified("dope_memory")
+    search = SA.memory_search(
+        ownership=own,
+        client=client,
+        base_url="http://127.0.0.1:3020",
+        workspace_id="ws",
+        query="q",
+    )
+    replay = SA.memory_replay_session(
+        ownership=own,
+        client=client,
+        base_url="http://127.0.0.1:3020",
+        workspace_id="ws",
+        session_id="s1",
+    )
+    assert search.allowed and replay.allowed
+    paths = [c["url"] for c in transport.calls]
+    assert any("memory_search" in u for u in paths)
+    assert any("memory_replay_session" in u for u in paths)
+
+
+def test_memory_write_not_release_one():
+    assert not is_release_one_operation("dope_memory", "memory_store")
+    denied = SA.deny_blocked_operation("memory_store", "dope_memory")
+    assert denied.allowed is False
+
+
+def test_adapter_error_fail_closed():
+    def boom(**kwargs):
+        raise ReadOnlyHttpError("base_url host is not loopback")
+
+    client = ReadOnlyHttpClient(transport=boom)
+    result = SA.list_decisions(
+        ownership=_verified("conport"),
+        client=client,
+        base_url="http://127.0.0.1:3004",
+        workspace_id="ws",
+    )
+    assert result.allowed is False
+    assert "adapter error" in result.reason
+
+
+def test_public_dict_never_marks_callable():
+    transport = _FakeTransport()
+    client = ReadOnlyHttpClient(transport=transport)
+    result = SA.list_decisions(
+        ownership=_verified("conport"),
+        client=client,
+        base_url="http://127.0.0.1:3004",
+        workspace_id="ws",
+    )
+    pub = result.to_public_dict()
+    assert pub["callable"] is False
+    assert pub["allowed"] is True

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -137,6 +137,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0012 | DCP / MCP | Public Facade Target Contract Migration | Active | TP-DCP-MCP-RO-0011-REMEDIATION-01 |
 | TP-DCP-MCP-RO-0013 | DCP / MCP | Connector Policy Schema And Auth Context | Active | TP-DCP-MCP-RO-0012 |
 | TP-DCP-MCP-RO-0014 | DCP / MCP | Loopback Streamable HTTP Ingress | Active | TP-DCP-MCP-RO-0013 |
+| TP-DCP-MCP-RO-0015 | DCP / MCP | Ownership Verification And Release-One Adapters | Active | TP-DCP-MCP-RO-0014 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json
@@ -1,0 +1,103 @@
+{
+  "id": "TP-DCP-MCP-RO-0015",
+  "project": "dopemux-mvp",
+  "target": "Implement fail-closed ownership verification and release-one safe adapters for ConPort decision list/read and dope-memory search/replay without live backends, writes, or non-release families.",
+  "invariants": [
+    "Port presence alone never verifies ownership.",
+    "Ownership verification never sets callable true by itself.",
+    "Release-one allows only ConPort list/get decision and dope-memory search/replay.",
+    "Progress, broad query, writes, dope-context, task-orchestrator, and bridge remain blocked.",
+    "Tests inject HTTP transports; no live network, tunnel, or credential is required."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0014"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0014",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0015-ownership-adapters",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0014 loopback ingress is merged on main (PR #1060)."
+  },
+  "commit": {
+    "message": "feat(dcp): add ownership verification and release-one adapters",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/ownership.py",
+      "services/dcp-readonly-facade/src/dcp_facade/safe_adapters.py",
+      "services/dcp-readonly-facade/src/dcp_facade/conport.py",
+      "services/dcp-readonly-facade/src/dcp_facade/route_manifest.py",
+      "services/dcp-readonly-facade/tests/test_ownership.py",
+      "services/dcp-readonly-facade/tests/test_safe_adapters.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/OWNERSHIP_AND_SAFE_ADAPTERS.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0015/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ownership.py services/dcp-readonly-facade/tests/test_safe_adapters.py",
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+      "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): add ownership verification and release-one adapters",
+    "body": "Implements TP-DCP-MCP-RO-0015: fail-closed ownership verification (no port-only trust) and release-one safe adapters for ConPort decisions and dope-memory search/replay. No live backends, tunnels, writes, or non-release families.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "ownership-verifier",
+      "task": "Implement pure ownership evidence adjudication with fail-closed matrix for wrong project, ambiguous, stale, unlabeled, protocol, mount, and port-only cases.",
+      "validation": [
+        "Port-only evidence is blocked.",
+        "Happy-path evidence with labels, roots, mounts, and protocol_ok verifies without callable true."
+      ]
+    },
+    {
+      "id": "release-one-adapters",
+      "task": "Gate ConPort decision list/read and dope-memory search/replay behind verified ownership; deny progress/writes.",
+      "validation": [
+        "Denied ops never issue HTTP.",
+        "Allowed ops require verified ownership and use injected transport only."
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Run focused/full tests, packet schema validation, pre-commit, advisory AGY, open PR without merge.",
+      "validation": [
+        "Local validation captured in proof.",
+        "Trusted embedded audit not claimed from AGY."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.md
@@ -1,0 +1,38 @@
+---
+id: TP-DCP-MCP-RO-0015
+title: Ownership Verification And Release-One Adapters
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Fail-closed ownership verification and release-one ConPort/dope-memory adapter gates.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0015
+
+## Objective
+
+Prove ownership of runtime candidates without port-only trust, and expose only
+release-one safe adapter operations for ConPort decisions and dope-memory
+search/replay behind that verdict.
+
+## Scope
+
+IN: ownership verifier, release-one safe adapter gate, decision-by-id helper,
+route manifest release-one tables, tests, docs, packet, proof.
+
+OUT: live network by default, tunnels, writes, progress reads, dope-context,
+task-orchestrator, bridge, public tool surface expansion, credentials.
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ownership.py services/dcp-readonly-facade/tests/test_safe_adapters.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+```
+
+## Rollback
+
+Revert the TP-0015 commits. Legacy Phase-1 helpers remain; release-one gate is
+removed.


### PR DESCRIPTION
## Summary

Implements **TP-DCP-MCP-RO-0015** on merged TP-0014 (#1060).

- Pure ownership verifier: rejects port-only, wrong project, ambiguous, stale, unlabeled, mount/protocol failures
- Release-one safe adapter gate: ConPort `list_decisions` / `get_decision`; dope-memory `memory_search` / `memory_replay_session`
- Progress / writes / non-release families blocked
- Injected HTTP transports in tests only (no live backends)

## Out of scope

Live protocol probes against real services, public FastMCP tool wiring, tunnels, dope-context, task-orchestrator, bridge.

## Validation (local)

- Focused tests: 20 passed
- Full facade suite: passed (1 opt-in live skipped)
- compileall, packet schema, pre-commit: passed
- AGY: timed out → recorded NOT_RUN; manual local review residual live-probe gap

## Readiness blockers

- Trusted embedded audit: SKIPPED / not claimed
- PR Steward / merge readiness: not claimed

## Packet / proof

- `task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0015.json`
- `proof/TP-DCP-MCP-RO-0015/`