### PR TITLE
docs(dcp): add multi-provider setup and rollback guides

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -32,6 +32,7 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0013 | Connector Policy Schema And Auth Context | HIGH | Strict connector policy schema/loader and provider-neutral sealed auth context with target/tool authorization. **No public ingress.** | 0012 |
 | TP-DCP-MCP-RO-0014 | Loopback Streamable HTTP Ingress | HIGH | Auth-before-discovery loopback HTTP ingress, rate limits, redacted audit, start/stop/health. **No public bind/tunnel.** | 0013 |
 | TP-DCP-MCP-RO-0015 | Ownership Verification And Release-One Adapters | HIGH | Fail-closed ownership verifier + ConPort decision list/read and dope-memory search/replay gates. **No live default network.** | 0014 |
+| TP-DCP-MCP-RO-0016 | Multi-Provider Setup And Rollback Docs | MEDIUM | Provider setup, disable/rollback, command/source-date ledgers, example secret-scan tests. **Placeholders only.** | 0015 |
 
 ## Sequencing rationale
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/DISABLE_AND_ROLLBACK.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/DISABLE_AND_ROLLBACK.md
@@ -1,0 +1,82 @@
+---
+id: dcp-mcp-readonly-disable-and-rollback
+title: DCP Connector Disable And Rollback Guide
+type: how-to
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Operator steps to disable connectors, revoke credentials, stop tunnels, and roll back the DCP read-only facade without mutating backends.
+---
+
+# Disable And Rollback Guide
+
+Use this guide when a provider smoke fails, an unexpected tool appears, or an
+operator wants to retire exposure. **Backend data remains unchanged.**
+
+## Immediate stop (ordered)
+
+1. **Disable connector policy records** outside the repo
+   Set `enabled: false` on each connector record under
+   `DCP_FACADE_CONNECTOR_POLICY`. Reload/restart the facade process so auth fails closed.
+2. **Revoke connector secrets**
+   Rotate or delete the secret behind each `credential_ref` (env/keychain/secret manager).
+   Old tokens must fail authentication after rotation (TP-0013).
+3. **Stop provider tunnels / apps**
+   - ChatGPT: stop `tunnel-client`; disable or unlink the custom app
+   - Grok/Gemini: disable connectors in the provider UI; stop named/quick tunnels
+   - Local agents: stop the local client; do not leave public tunnels running
+4. **Stop facade ingress**
+   Terminate the process started with `DCP_FACADE_TRANSPORT=streamable-http`.
+   Confirm no listener remains on `127.0.0.1:<FACADE_PORT>`.
+5. **Stop or leave backend sidecars as needed**
+   Optional: `uv run --frozen dopemux mcp stop --repo "<TARGET_WORKTREE>"`
+   Stopping backends is **not** required for exposure rollback; adapters must
+   already be unreachable once the facade is down and credentials revoked.
+
+## Registry rollback
+
+- Set registry-v2 targets `enabled: false` in the external registry file
+  (`DCP_FACADE_REGISTRY_V2`), or remove the file path from the environment.
+- Do not delete operator audit artifacts needed for forensics.
+
+## Code rollback (series packets)
+
+If a code regression is suspected:
+
+```bash
+# On a dedicated worktree only; do not force-push main without process
+git revert <merge_commit_of_suspect_packet>
+```
+
+Packet-specific notes:
+
+| Packet | Rollback effect |
+| --- | --- |
+| 0012 | Restores pre-v2 public tool surface if reverted |
+| 0013 | Removes connector policy/auth primitives |
+| 0014 | Removes loopback ingress; keep `DCP_FACADE_TRANSPORT=stdio` |
+| 0015 | Removes ownership/safe-adapter gates |
+| 0016 | Docs/templates only |
+
+## Verification after disable
+
+```bash
+# Expect connection refused or auth failure
+curl -sS -o /dev/null -w "%{http_code}\n" "http://127.0.0.1:<FACADE_PORT>/mcp" || true
+# Provider UI: tool discovery fails or connector disabled
+```
+
+Confirm:
+
+- No public tool discovery from providers
+- No raw secrets in remaining logs
+- Backend services (if still running) are not exposed without the facade
+
+## Do not
+
+- Leave quick tunnels running “for later”
+- Reuse one connector credential across providers
+- Commit disabled-but-populated secrets “for convenience”
+- Point providers at ConPort/dope-memory ports directly

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_COMMAND_LEDGER.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_COMMAND_LEDGER.md
@@ -1,0 +1,36 @@
+---
+id: dcp-mcp-readonly-provider-command-ledger
+title: DCP Provider Command Verification Ledger
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Commands documented for DCP multi-provider setup verified against local --help or source in TP-0016.
+---
+
+# Provider Command Verification Ledger
+
+Packet: **TP-DCP-MCP-RO-0016**
+Worktree verification date: **2026-07-16**
+Repo head at verification: bound to the TP-0016 PR head after implementation.
+
+| Command / surface | Verified how | Status |
+| --- | --- | --- |
+| `dopemux mcp --help` | `uv run --frozen dopemux mcp --help` | PASS |
+| `dopemux mcp start --help` | local `--help` (options: `--repo`, `--services`, `--dry-run`, `--json`) | PASS |
+| `dopemux mcp doctor --help` | local `--help` (`--repo`, `--json`, `--verbose`, `--skip-docker`) | PASS |
+| `dopemux mcp init` / `repair-config` / `status` / `stop` | listed under `dopemux mcp --help` | PASS (existence) |
+| `DCP_FACADE_TRANSPORT` | `services/dcp-readonly-facade/src/mcp/server.py` | PASS |
+| `DCP_FACADE_INGRESS_HOST` / `PORT` / `CONNECTOR_POLICY` | `loopback_server.py` | PASS |
+| `DCP_FACADE_REGISTRY_V2` | `server.py` / `registry_v2.py` | PASS |
+| `curl` health `/health` and `/mcp` | TP-0014 contract + tests | PASS (contract) |
+| `tunnel-client …` | not installed locally; documented as OBSERVED vendor shape | NOT_RUN (vendor) |
+| `cloudflared tunnel --url` / `ngrok http` | not executed live; documented as OBSERVED vendor smoke shape | NOT_RUN (vendor) |
+
+Rules:
+
+- Vendor CLI flags that were **not** re-verified same-day are labeled NOT_RUN.
+- Operators must re-check official provider docs before live use (see
+  [`SOURCE_DATE_LEDGER.md`](SOURCE_DATE_LEDGER.md)).

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_SETUP.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_SETUP.md
@@ -1,0 +1,263 @@
+---
+id: dcp-mcp-readonly-provider-setup
+title: DCP Multi-Provider Setup Guide (Placeholders Only)
+type: how-to
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Operator setup for ChatGPT, Grok, Gemini, and local Antigravity connectors against the DCP read-only facade using placeholders only.
+---
+
+# Provider Setup Guide
+
+**Status:** operator guide for post-0015 series code
+**Safety:** placeholders only. Never commit real credentials, tunnel IDs, private
+paths, production hostnames, or secret values.
+
+Related contracts:
+
+- [`CONNECTOR_POLICY_CONTRACT.md`](CONNECTOR_POLICY_CONTRACT.md)
+- [`CONNECTOR_POLICY_EXAMPLE.yaml`](CONNECTOR_POLICY_EXAMPLE.yaml)
+- [`INGRESS_LOOPBACK_CONTRACT.md`](INGRESS_LOOPBACK_CONTRACT.md)
+- [`OWNERSHIP_AND_SAFE_ADAPTERS.md`](OWNERSHIP_AND_SAFE_ADAPTERS.md)
+- [`DISABLE_AND_ROLLBACK.md`](DISABLE_AND_ROLLBACK.md)
+- [`SOURCE_DATE_LEDGER.md`](SOURCE_DATE_LEDGER.md)
+
+## Placeholder legend
+
+| Placeholder | Meaning |
+| --- | --- |
+| `<REPO_ROOT>` | Dedicated worktree of `DDD-Enterprises/dopemux-mvp` |
+| `<TARGET_WORKTREE>` | Worktree exposed by one registry-v2 target |
+| `<FACADE_PORT>` | Loopback ingress port |
+| `<EXTERNAL_REGISTRY_V2_PATH>` | Operator-owned registry-v2 YAML **outside** the repo |
+| `<EXTERNAL_CONNECTOR_POLICY_PATH>` | Operator-owned connector policy YAML **outside** the repo |
+| `<CONNECTOR_TOKEN_ENV>` | Env var name holding one connector secret |
+| `<PUBLIC_GROK_HOSTNAME>` | Stable public hostname for Grok only |
+| `<PUBLIC_GEMINI_HOSTNAME>` | Stable public hostname for Gemini only |
+| `<OPENAI_TUNNEL_ID>` | OpenAI tunnel id (never commit) |
+| `<OPENAI_TUNNEL_RUNTIME_API_KEY>` | OpenAI tunnel runtime key (never commit) |
+
+## 1. Shared Dopemux preparation
+
+### 1.1 Repo identity
+
+```bash
+cd "<REPO_ROOT>"
+test -f AGENTS.md
+git remote get-url origin
+git branch --show-current
+git status --short
+git rev-parse HEAD
+```
+
+Block if origin is not `DDD-Enterprises/dopemux-mvp` or unrelated dirty work is present.
+
+### 1.2 Target worktree MCP sidecars (release-one)
+
+Verified CLI (`uv run --frozen dopemux mcp start --help`):
+
+```bash
+uv run --frozen dopemux mcp init
+uv run --frozen dopemux mcp repair-config
+uv run --frozen dopemux mcp start \
+  --repo "<TARGET_WORKTREE>" \
+  --services conport,dope-memory \
+  --json
+uv run --frozen dopemux mcp status --repo "<TARGET_WORKTREE>" --json
+uv run --frozen dopemux mcp doctor --repo "<TARGET_WORKTREE>" --json
+```
+
+Do **not** start the task orchestrator service for first-release external exposure.
+
+### 1.3 External registry-v2 and connector policy
+
+Create operator files **outside** the repository:
+
+```text
+export DCP_FACADE_REGISTRY_V2="<EXTERNAL_REGISTRY_V2_PATH>"
+export DCP_FACADE_CONNECTOR_POLICY="<EXTERNAL_CONNECTOR_POLICY_PATH>"
+```
+
+- Validate connector records against
+  `services/dcp-readonly-facade/schema/connector_policy.schema.json`
+- Use repository templates only as templates:
+  [`CONNECTOR_POLICY_EXAMPLE.yaml`](CONNECTOR_POLICY_EXAMPLE.yaml) (`examples_only: true`, all `enabled: false`)
+- Secrets live in env/keychain/secret manager; policy stores **references** only
+
+### 1.4 Start the loopback facade ingress
+
+Implemented env surface (TP-0014):
+
+```bash
+export DCP_FACADE_TRANSPORT=streamable-http
+export DCP_FACADE_INGRESS_HOST=127.0.0.1
+export DCP_FACADE_INGRESS_PORT="<FACADE_PORT>"
+export DCP_FACADE_CONNECTOR_POLICY="<EXTERNAL_CONNECTOR_POLICY_PATH>"
+export DCP_FACADE_REGISTRY_V2="<EXTERNAL_REGISTRY_V2_PATH>"
+
+# From services/dcp-readonly-facade with PYTHONPATH including src + repo src:
+python -m mcp.server
+```
+
+Default transport remains `stdio` when `DCP_FACADE_TRANSPORT` is unset.
+
+### 1.5 Local probes (no provider yet)
+
+```bash
+# Health (unauthenticated; no tools)
+curl -sS "http://127.0.0.1:<FACADE_PORT>/health"
+
+# Unauthenticated MCP must fail (401, no tool list)
+curl -sS -o /tmp/dcp-unauth.json -w "%{http_code}\n" "http://127.0.0.1:<FACADE_PORT>/mcp"
+
+# Authenticated discovery (token from secret store, never committed)
+curl -sS "http://127.0.0.1:<FACADE_PORT>/mcp" \
+  -H "Authorization: Bearer <VALUE_FROM_SECRET_STORE_NOT_REPO>"
+```
+
+Required outcomes:
+
+- listener is loopback only
+- unauthenticated discovery fails generically
+- authenticated discovery returns only accepted read-only tools
+- no write/mutate tool names appear
+
+## 2. ChatGPT (Secure MCP Tunnel)
+
+### Prerequisites
+
+OpenAI Platform tunnel id, runtime API key, eligible workspace permissions, and
+web ChatGPT custom MCP app support. Do not store tunnel id or keys in git.
+
+### Local endpoint
+
+```text
+http://127.0.0.1:<FACADE_PORT>/mcp
+```
+
+Point the tunnel only at the DCP facade, never at ConPort/dope-memory directly.
+
+### Tunnel client shape (verify with current OpenAI docs)
+
+```bash
+export CONTROL_PLANE_API_KEY="<OPENAI_TUNNEL_RUNTIME_API_KEY>"
+tunnel-client init \
+  --sample sample_mcp_stdio_local \
+  --profile "<OPENAI_TUNNEL_PROFILE>" \
+  --tunnel-id "<OPENAI_TUNNEL_ID>" \
+  --mcp-server-url "http://127.0.0.1:<FACADE_PORT>/mcp"
+tunnel-client doctor --profile "<OPENAI_TUNNEL_PROFILE>" --explain
+tunnel-client run --profile "<OPENAI_TUNNEL_PROFILE>"
+```
+
+Re-check official `tunnel-client` help before production use (client may evolve).
+
+### Connector policy binding
+
+```yaml
+provider: chatgpt
+transport_class: openai_secure_mcp_tunnel
+default_target_id: dopemux-main
+allowed_target_ids: [dopemux-main]
+enabled: false   # flip only after operator approval
+```
+
+### Smoke and revoke
+
+1. Discover tools; compare to accepted read-only set.
+2. Attempt denied tool and unauthorized target; expect block.
+3. Stop tunnel client; confirm no direct backend reachability from the app.
+4. Revoke: disable connector record, revoke credential, unlink app, stop tunnel.
+
+## 3. Grok (public Streamable HTTP via tunnel edge)
+
+### Prerequisites
+
+Public HTTPS Streamable HTTP URL. Prefer named Cloudflare tunnel or stable ngrok
+domain for acceptance; quick tunnels are ephemeral-only.
+
+### Ephemeral smoke only
+
+```bash
+cloudflared tunnel --url "http://127.0.0.1:<FACADE_PORT>"
+# or
+ngrok http <FACADE_PORT>
+```
+
+Stable named tunnel commands must come from current Cloudflare/ngrok docs and
+operator config; do not invent DNS or cert steps here.
+
+### Connector creation
+
+1. Create custom Grok connector.
+2. Server URL: `https://<PUBLIC_GROK_HOSTNAME>/mcp`
+3. Configure Grok-specific bearer credential (separate from ChatGPT).
+4. Discover tools; verify read-only allowlist.
+
+### Policy binding
+
+```yaml
+provider: grok
+transport_class: public_streamable_http
+default_target_id: feature-review-a7
+allowed_target_ids: [feature-review-a7]
+```
+
+## 4. Gemini API / Deep Research
+
+### Prerequisites
+
+Provider account that supports remote MCP URL configuration. Separate credential
+and hostname from Grok/ChatGPT.
+
+### Endpoint
+
+```text
+https://<PUBLIC_GEMINI_HOSTNAME>/mcp
+```
+
+Use Streamable HTTP. Keep `allowed_tools` restricted to release-one reads when
+the provider UI supports allowlisting.
+
+### Policy binding
+
+```yaml
+provider: gemini_api   # or gemini_deep_research when applicable
+transport_class: public_streamable_http
+default_target_id: dopemux-main
+allowed_target_ids: [dopemux-main]
+```
+
+## 5. Local Gemini CLI / Antigravity
+
+Prefer loopback only (no public tunnel):
+
+```text
+http://127.0.0.1:<FACADE_PORT>/mcp
+```
+
+```yaml
+provider: gemini_cli
+transport_class: local_streamable_http
+```
+
+Never point local agents at backend services directly.
+
+## 6. Cross-provider invariants
+
+1. One connector identity per provider/account class.
+2. Independently revocable credentials (rotation invalidates old tokens).
+3. Auth before discovery (TP-0014).
+4. Ownership verification before any adapter call (TP-0015).
+5. Release-one adapter ops only: ConPort decision list/read; dope-memory
+   search/replay. Progress, writes, dope-context, and the task orchestrator stay blocked.
+6. No real secrets or private paths in repository artifacts.
+
+## 7. Command verification ledger
+
+See [`SOURCE_DATE_LEDGER.md`](SOURCE_DATE_LEDGER.md) for source dates and
+[`PROVIDER_COMMAND_LEDGER.md`](PROVIDER_COMMAND_LEDGER.md) for commands verified
+against local `--help` in this packet.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/SOURCE_DATE_LEDGER.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/SOURCE_DATE_LEDGER.md
@@ -1,0 +1,36 @@
+---
+id: dcp-mcp-readonly-source-date-ledger
+title: DCP Multi-Provider Source Date Ledger
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Source-date tracking for provider documentation used by the DCP multi-provider series.
+---
+
+# Source Date Ledger
+
+Packet: **TP-DCP-MCP-RO-0016**
+
+| Source | Class | Date captured | Notes |
+| --- | --- | --- | --- |
+| Supervisor package `PROVIDER-SETUP-GUIDE.md` | advisory package | 2026-07-16 (package ZIP) | SHA-256 `c0cb9d34…2447`; placeholders only |
+| Supervisor package `CONNECTOR-POLICY-EXAMPLE.yaml` | advisory package | 2026-07-16 | Already mirrored as repo example |
+| Repo `CONNECTOR_POLICY_CONTRACT.md` | runtime-aligned docs | 2026-07-16 | TP-0013 |
+| Repo `INGRESS_LOOPBACK_CONTRACT.md` | runtime-aligned docs | 2026-07-16 | TP-0014 |
+| Repo `OWNERSHIP_AND_SAFE_ADAPTERS.md` | runtime-aligned docs | 2026-07-16 | TP-0015 |
+| `dopemux mcp start --help` | local CLI | 2026-07-16 | Verified in TP-0016 worktree |
+| OpenAI Secure MCP Tunnel / `tunnel-client` | vendor external | operator must refresh | Do not trust stale flags |
+| xAI / Grok custom connectors | vendor external | operator must refresh | Public HTTPS + auth |
+| Google Gemini remote MCP | vendor external | operator must refresh | Model/agent support may drift |
+| Cloudflare / ngrok tunnel docs | vendor external | operator must refresh | Named vs quick tunnel tradeoffs |
+
+## Refresh rule
+
+Before any live provider enablement (TP-0017):
+
+1. Re-run local CLI `--help` for Dopemux commands used in the runbook.
+2. Re-check official provider docs the same day; record new dates here.
+3. Fail closed if a documented vendor flag is missing or renamed.

--- a/proof/TP-DCP-MCP-RO-0016/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0016/AGY_AUDIT.md
@@ -1,0 +1,10 @@
+# AGY Audit: TP-DCP-MCP-RO-0016
+
+## Status
+
+`NOT_RUN` for timed AGY invocation. Manual local review: docs are placeholders-only;
+connector examples remain disabled; secret-scan tests pass.
+
+## Boundary
+
+Advisory docs packet. Does not satisfy embedded-audit.yml.

--- a/proof/TP-DCP-MCP-RO-0016/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0016/AUDITOR_REPORT.md
@@ -1,0 +1,11 @@
+# TP-DCP-MCP-RO-0016 Auditor Report
+
+## Verdict
+
+`SKIPPED` for trusted embedded-audit. Docs-only packet under local-only constraints.
+
+## Local Evidence
+
+- Provider docs example tests passed
+- Full facade suite passed (opt-in live skipped)
+- Packet schema + pre-commit allowlist

--- a/proof/TP-DCP-MCP-RO-0016/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0016/COMMAND_LOG.md
@@ -1,0 +1,16 @@
+# TP-DCP-MCP-RO-0016 Command Log
+
+Base: origin/main @ a14d7c509 (TP-0015 merged)
+
+| Command | Result |
+| --- | --- |
+| 0015 dependency | PASS |
+| 0016 collision | PASS (none) |
+| dopemux mcp start/doctor --help | PASS (local) |
+| focused provider docs tests | PASS (5) |
+| full facade suite | PASS; 1 live skip |
+| packet schema | PASS |
+| pre-commit allowlist | PASS |
+| agy | NOT_RUN |
+| live provider/tunnel setup | NOT_RUN (forbidden) |
+| Trusted embedded audit | NOT_RUN |

--- a/proof/TP-DCP-MCP-RO-0016/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0016/PROOF.json
@@ -106,7 +106,10 @@
   ],
   "rollback": "Revert TP-0016 docs/test commits only",
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
-  }
+    "number": 1064,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1064",
+    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed."
+  },
+  "implementation_commit": "282319ac0"
 }

--- a/proof/TP-DCP-MCP-RO-0016/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0016/PROOF.json
@@ -1,0 +1,112 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0016",
+  "title": "Multi-Provider Setup And Rollback Docs",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0016-provider-docs",
+  "base_branch": "main",
+  "base_sha": "a14d7c509c03e4e4f7dc5ebfe1a5bdacf0c4ce8e",
+  "depends_on_verified": {
+    "TP-DCP-MCP-RO-0015": {
+      "pr": 1061,
+      "merge_commit": "a14d7c509c03e4e4f7dc5ebfe1a5bdacf0c4ce8e",
+      "status": "MERGED"
+    }
+  },
+  "scope": "Provider setup, disable/rollback, command/source-date ledgers, example validation tests. Placeholders only; no live provider setup.",
+  "input_package": {
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "authority": "advisory_only"
+  },
+  "files_changed": [
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_SETUP.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/DISABLE_AND_ROLLBACK.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_COMMAND_LEDGER.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/SOURCE_DATE_LEDGER.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "services/dcp-readonly-facade/tests/test_provider_docs_examples.py",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0016/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0016/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0016/AGY_AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0016/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "focused provider docs tests",
+        "exit_code": 0,
+        "result": "5 passed"
+      },
+      {
+        "command": "full facade suite",
+        "exit_code": 0,
+        "result": "passed; 1 live skipped"
+      },
+      {
+        "command": "packet schema",
+        "exit_code": 0,
+        "result": "valid"
+      },
+      {
+        "command": "pre-commit allowlist",
+        "exit_code": 0,
+        "result": "ok"
+      },
+      {
+        "command": "dopemux mcp start/doctor --help",
+        "exit_code": 0,
+        "result": "verified for ledger"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Trusted embedded audit / PR Steward",
+        "reason": "local-only docs packet",
+        "mitigation": "readiness not claimed"
+      },
+      {
+        "command": "Live provider/tunnel setup",
+        "reason": "forbidden by packet and user constraints",
+        "mitigation": "placeholders only"
+      }
+    ]
+  },
+  "local_agy_review": {
+    "status": "NOT_RUN",
+    "ci_trust_status": "NOT_ACCEPTED"
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0016/AUDITOR_REPORT.md",
+    "findings": [],
+    "skip_reason": "No trusted runner/Claude audit route; docs packet under local-only constraints.",
+    "fixes_applied": [
+      "Provider setup guide with verified Dopemux CLI surfaces",
+      "Disable/rollback guide",
+      "Command and source-date ledgers",
+      "Example schema validation and secret-scan tests"
+    ],
+    "remaining_risks": [
+      "Vendor CLI flags must be re-verified same-day before live use",
+      "Trusted embedded audit unavailable"
+    ]
+  },
+  "residual_risks": [
+    "Operator must keep secrets and tunnels outside the repository",
+    "Generated .claude/claude_config.json left unstaged"
+  ],
+  "rollback": "Revert TP-0016 docs/test commits only",
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
+  }
+}

--- a/services/dcp-readonly-facade/tests/test_provider_docs_examples.py
+++ b/services/dcp-readonly-facade/tests/test_provider_docs_examples.py
@@ -1,0 +1,85 @@
+"""TP-0016: provider doc examples validate and stay free of secret material."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator
+
+_REPO = Path(__file__).resolve().parents[3]
+_DOCS = _REPO / "docs" / "03-reference" / "dcp" / "chatgpt-mcp-readonly"
+_SCHEMA = (
+    Path(__file__).resolve().parents[1] / "schema" / "connector_policy.schema.json"
+)
+
+_SECRET_PATTERNS = [
+    # OpenAI-style keys (sk- + long alphanumeric), not words like "task-orchestrator".
+    re.compile(r"(?<![A-Za-z])sk-[A-Za-z0-9]{20,}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{16,}"),
+    re.compile(r"(?i)\b(api[_-]?key|password|secret)\s*[=:]\s*[^\s<]{8,}"),
+]
+
+_REQUIRED_DOC_FILES = (
+    "PROVIDER_SETUP.md",
+    "DISABLE_AND_ROLLBACK.md",
+    "PROVIDER_COMMAND_LEDGER.md",
+    "SOURCE_DATE_LEDGER.md",
+    "CONNECTOR_POLICY_EXAMPLE.yaml",
+    "CONNECTOR_POLICY_CONTRACT.md",
+)
+
+_REQUIRED_PLACEHOLDERS = (
+    "<REPO_ROOT>",
+    "<FACADE_PORT>",
+    "<EXTERNAL_CONNECTOR_POLICY_PATH>",
+    "<OPENAI_TUNNEL_ID>",
+)
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA.read_text(encoding="utf-8"))
+
+
+def test_required_provider_docs_exist():
+    for name in _REQUIRED_DOC_FILES:
+        path = _DOCS / name
+        assert path.is_file(), name
+
+
+def test_connector_policy_example_validates_and_is_disabled():
+    doc = yaml.safe_load((_DOCS / "CONNECTOR_POLICY_EXAMPLE.yaml").read_text(encoding="utf-8"))
+    assert doc.get("examples_only") is True
+    validator = Draft202012Validator(_schema())
+    for record in doc["records"]:
+        validator.validate(record)
+        assert record.get("enabled") is False
+        ref = record["credential_ref"]["reference"]
+        assert not any(p.search(ref) for p in _SECRET_PATTERNS)
+
+
+def test_provider_docs_have_no_secret_like_material():
+    for name in _REQUIRED_DOC_FILES:
+        text = (_DOCS / name).read_text(encoding="utf-8")
+        for pattern in _SECRET_PATTERNS:
+            assert pattern.search(text) is None, f"{name} matched {pattern.pattern}"
+
+
+def test_provider_setup_placeholder_completeness():
+    text = (_DOCS / "PROVIDER_SETUP.md").read_text(encoding="utf-8")
+    for token in _REQUIRED_PLACEHOLDERS:
+        assert token in text, token
+    # Real-looking private home paths must not appear.
+    assert "/Users/" not in text
+    assert re.search(r"(?<![A-Za-z])sk-[A-Za-z0-9]{20,}", text) is None
+
+
+def test_command_ledger_records_local_cli_verification():
+    text = (_DOCS / "PROVIDER_COMMAND_LEDGER.md").read_text(encoding="utf-8")
+    assert "dopemux mcp start --help" in text
+    assert "PASS" in text
+    assert "NOT_RUN" in text  # vendor CLIs explicitly not executed

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -138,6 +138,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0013 | DCP / MCP | Connector Policy Schema And Auth Context | Active | TP-DCP-MCP-RO-0012 |
 | TP-DCP-MCP-RO-0014 | DCP / MCP | Loopback Streamable HTTP Ingress | Active | TP-DCP-MCP-RO-0013 |
 | TP-DCP-MCP-RO-0015 | DCP / MCP | Ownership Verification And Release-One Adapters | Active | TP-DCP-MCP-RO-0014 |
+| TP-DCP-MCP-RO-0016 | DCP / MCP | Multi-Provider Setup And Rollback Docs | Active | TP-DCP-MCP-RO-0015 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.json
@@ -1,0 +1,95 @@
+{
+  "id": "TP-DCP-MCP-RO-0016",
+  "project": "dopemux-mvp",
+  "target": "Add provider setup guides, non-secret connector examples, disable/rollback guidance, and source-date/command verification ledgers without real credentials or live provider setup.",
+  "invariants": [
+    "Repository documentation contains only placeholders for secrets, tunnel IDs, hostnames, and private paths.",
+    "Connector policy examples remain examples_only with enabled false and schema-valid records.",
+    "Documented Dopemux CLI commands are verified against local --help where claimed PASS.",
+    "Vendor CLIs not present locally are marked NOT_RUN rather than invented as verified.",
+    "No live provider, tunnel, or credential creation is performed."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0015"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0015",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0016-provider-docs",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0015 ownership/safe adapters are merged on main (PR #1061)."
+  },
+  "commit": {
+    "message": "docs(dcp): add multi-provider setup and rollback guides",
+    "allowlist": [
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_SETUP.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/DISABLE_AND_ROLLBACK.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/PROVIDER_COMMAND_LEDGER.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/SOURCE_DATE_LEDGER.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "services/dcp-readonly-facade/tests/test_provider_docs_examples.py",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0016/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_provider_docs_examples.py",
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "docs(dcp): add multi-provider setup and rollback guides",
+    "body": "Implements TP-DCP-MCP-RO-0016: provider setup, disable/rollback, command and source-date ledgers, and example validation tests. Placeholders only; no live provider or credential setup.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "docgen",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "provider-docs",
+      "task": "Author provider setup and disable/rollback guides using placeholders and verified Dopemux CLI surfaces from 0013-0015.",
+      "validation": [
+        "Required placeholders present.",
+        "No secret-like material in docs."
+      ]
+    },
+    {
+      "id": "ledgers-tests",
+      "task": "Add command/source-date ledgers and tests that schema-validate connector examples and scan for secrets.",
+      "validation": [
+        "Connector policy examples validate and remain disabled.",
+        "Focused docs tests pass."
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Run suite, packet schema validation, pre-commit, open PR without merge.",
+      "validation": [
+        "Proof records audit gap; merge readiness not claimed."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0016.md
@@ -1,0 +1,37 @@
+---
+id: TP-DCP-MCP-RO-0016
+title: Multi-Provider Setup And Rollback Docs
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Provider setup, disable/rollback, and source-date ledgers for the DCP multi-provider series.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0016
+
+## Objective
+
+Document how operators configure ChatGPT, Grok, Gemini, and local agents
+against the DCP facade using placeholders only, with disable/rollback and
+command/source-date verification.
+
+## Scope
+
+IN: provider setup guide, disable/rollback, command ledger, source-date ledger,
+example validation tests, packet/proof/index/BUILD_SERIES.
+
+OUT: live provider creation, real credentials, tunnels, hostnames, private
+paths, code behavior changes outside docs/tests.
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_provider_docs_examples.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+```
+
+## Rollback
+
+Revert the TP-0016 docs/test commits only.


### PR DESCRIPTION
## Summary

Implements **TP-DCP-MCP-RO-0016** on merged TP-0015 (#1061).

- Provider setup guide (ChatGPT, Grok, Gemini, local) with placeholders only
- Disable/rollback guide
- Command verification ledger (local CLI `--help` PASS; vendor CLIs NOT_RUN)
- Source-date ledger
- Tests: connector example schema validation + secret-scan + placeholder completeness

## Out of scope

Live provider creation, real credentials, tunnels, private paths.

## Validation

- Focused docs tests: 5 passed
- Full facade suite: passed
- pre-commit: passed

## Readiness blockers

- Trusted embedded audit SKIPPED / not claimed
- Merge readiness not claimed