### PR TITLE
feat(audit): add exact-head proof readiness evaluator

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -34,6 +34,7 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0015 | Ownership Verification And Release-One Adapters | HIGH | Fail-closed ownership verifier + ConPort decision list/read and dope-memory search/replay gates. **No live default network.** | 0014 |
 | TP-DCP-MCP-RO-0016 | Multi-Provider Setup And Rollback Docs | MEDIUM | Provider setup, disable/rollback, command/source-date ledgers, example secret-scan tests. **Placeholders only.** | 0015 |
 | TP-DCP-MCP-RO-0017 | Acceptance Matrix And Fail-Closed Harness | CRITICAL | Matrix + harness: deterministic PASS, live NOT_RUN without dual consent; skipped live never PASS. | 0016 |
+| TP-DCP-MCP-RO-0018 | Exact-Head Proof Readiness Evaluator | HIGH | Fail-closed exact-head readiness; SKIPPED audit / stale proof / bad checks block READY. **No branch-protection mutation.** | 0017 |
 
 ## Sequencing rationale
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/EXACT_HEAD_READINESS.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/EXACT_HEAD_READINESS.md
@@ -1,0 +1,64 @@
+---
+id: dcp-mcp-readonly-exact-head-readiness
+title: DCP Exact-Head Proof Readiness Evaluator
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Fail-closed exact-head readiness evaluation for DCP multi-provider series proofs without mutating branch protection or audit routing.
+---
+
+# Exact-Head Proof Readiness
+
+Packet: **TP-DCP-MCP-RO-0018**
+
+## Purpose
+
+Emit a local `MERGE_READINESS`-style verdict bound to an exact git head.
+**READY** only when proof, audit, checks, reviews, and scope all match that head.
+
+This evaluator does **not**:
+
+- change branch protection
+- enable auto-merge
+- alter `embedded-audit.yml` routing
+- claim AGY satisfies trusted embedded audit
+
+## Module / CLI
+
+| Surface | Path |
+| --- | --- |
+| Library | `src/dopemux/audit/exact_head_readiness.py` |
+| CLI | `scripts/audit/exact_head_readiness.py` |
+
+```bash
+uv run --frozen python scripts/audit/exact_head_readiness.py \
+  --head-sha "$(git rev-parse HEAD)" \
+  --proof-json proof/TP-DCP-MCP-RO-0017/PROOF.json \
+  --checks-json /path/to/checks.json \
+  --out proof/TP-DCP-MCP-RO-0018/MERGE_READINESS.json
+echo $?   # 0 only when status==READY
+```
+
+## Fail-closed blockers
+
+| Condition | Blocker code |
+| --- | --- |
+| Proof head ≠ requested head | `proof_stale_to_head` |
+| Embedded audit SKIPPED/FAIL/missing | `embedded_audit_*` |
+| Failed checks | `failed_checks` |
+| Pending checks | `pending_checks` |
+| Checks for other SHA | `checks_stale_to_head` |
+| Unknown reviewer/bot | `unknown_reviewers_or_bots` |
+| Unresolved blocking thread | `blocking_thread_unresolved` |
+| Diff outside allowlist | `diff_escapes_packet_allowlist` |
+| Acceptance `release_ready` false (when required) | `acceptance_release_not_ready` |
+
+## Relationship to TP-0017
+
+When `--require-acceptance-ready` is set, a TP-0017
+`acceptance_report.json` with `release_ready: false` keeps status **BLOCKED**.
+Local-live-only acceptance is therefore **not** merge-ready for production
+exposure until vendor live gates pass.

--- a/proof/TP-DCP-MCP-RO-0018/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0018/AGY_AUDIT.md
@@ -1,0 +1,9 @@
+# AGY Audit: TP-DCP-MCP-RO-0018
+
+## Status
+
+`NOT_RUN`. Manual review: evaluator fail-closes on SKIPPED audit and stale head; no branch-protection or audit-routing changes.
+
+## Boundary
+
+Does not satisfy embedded-audit.yml.

--- a/proof/TP-DCP-MCP-RO-0018/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0018/AUDITOR_REPORT.md
@@ -1,0 +1,15 @@
+# TP-DCP-MCP-RO-0018 Auditor Report
+
+## Verdict
+
+`SKIPPED` for trusted embedded-audit.
+
+## Local Evidence
+
+- Unit tests for exact-head readiness passed (9)
+- Sample MERGE_READINESS against TP-0017 proof is BLOCKED (expected: skipped audit + acceptance not ready + proof head mismatch)
+- No branch protection or embedded-audit.yml changes
+
+## Boundary
+
+Series production READY still requires trusted audit + full live acceptance.

--- a/proof/TP-DCP-MCP-RO-0018/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0018/COMMAND_LOG.md
@@ -1,0 +1,12 @@
+# TP-DCP-MCP-RO-0018 Command Log
+
+Base: origin/main @ 8eee4e029 (TP-0017 merged)
+
+| Command | Result |
+| --- | --- |
+| 0017 dependency | PASS |
+| 0018 collision | PASS (none) |
+| pytest tests/audit/test_exact_head_readiness.py | PASS (9) |
+| exact_head_readiness vs 0017 proof | BLOCKED (expected) |
+| branch protection / audit routing edits | NOT_RUN (forbidden) |
+| Trusted embedded audit | NOT_RUN |

--- a/proof/TP-DCP-MCP-RO-0018/MERGE_READINESS.json
+++ b/proof/TP-DCP-MCP-RO-0018/MERGE_READINESS.json
@@ -1,0 +1,52 @@
+{
+  "base_branch": "main",
+  "blocking_thread_unresolved": false,
+  "branch": "",
+  "changed_files": [],
+  "checks": [
+    {
+      "conclusion": "success",
+      "head_sha": "8eee4e029208cf006dc8116a573953445d2b0841",
+      "matches_head_sha": true,
+      "name": "Unit Tests",
+      "status": "completed"
+    }
+  ],
+  "checks_stale_to_head": false,
+  "created_at": "2026-07-17T00:25:18.619686+00:00",
+  "diff_escapes_packet_allowlist": false,
+  "embedded_audit_status": "SKIPPED",
+  "evaluator": "scripts/audit/exact_head_readiness.py",
+  "failed_checks": [],
+  "head_sha": "8eee4e029208cf006dc8116a573953445d2b0841",
+  "notes": [
+    "READY requires embedded audit PASS/PASS_WITH_RISKS; SKIPPED fails closed.",
+    "Does not change branch protection or embedded-audit.yml routing.",
+    "Skipped live acceptance keeps require_acceptance_ready blocked when enabled."
+  ],
+  "packet_series": "TP-DCP-MCP-RO-0018",
+  "pending_checks": [],
+  "pr_number": 0,
+  "proof_bundle_refs": [
+    "services/dcp-readonly-facade/src/dcp_facade/acceptance.py",
+    "services/dcp-readonly-facade/tests/test_acceptance_harness.py",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/ACCEPTANCE_MATRIX.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0017/**"
+  ],
+  "proof_stale": true,
+  "ready_for_merge": false,
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "review_threads": [],
+  "schema_version": "1.0.0",
+  "status": "BLOCKED",
+  "unknown_reviewers_or_bots": [],
+  "unresolved_blockers": [
+    "proof_stale_to_head",
+    "embedded_audit_skipped",
+    "acceptance_release_not_ready"
+  ]
+}

--- a/proof/TP-DCP-MCP-RO-0018/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0018/PROOF.json
@@ -1,0 +1,99 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0018",
+  "title": "Exact-Head Proof Readiness Evaluator",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0018-proof-readiness",
+  "base_branch": "main",
+  "base_sha": "8eee4e029208cf006dc8116a573953445d2b0841",
+  "depends_on_verified": {
+    "TP-DCP-MCP-RO-0017": {
+      "pr": 1065,
+      "merge_commit": "8eee4e029208cf006dc8116a573953445d2b0841",
+      "status": "MERGED"
+    }
+  },
+  "scope": "Fail-closed exact-head readiness evaluator + negative tests. No branch protection or embedded-audit routing changes.",
+  "input_package": {
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "authority": "advisory_only"
+  },
+  "series_readiness_note": "Series code path 0012-0017 is on main for local/local-live slices. Production READY remains blocked until trusted embedded audit PASS and full live acceptance release_ready=true.",
+  "files_changed": [
+    "src/dopemux/audit/exact_head_readiness.py",
+    "src/dopemux/audit/__init__.py",
+    "scripts/audit/exact_head_readiness.py",
+    "tests/audit/test_exact_head_readiness.py",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/EXACT_HEAD_READINESS.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0018/**"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "pytest tests/audit/test_exact_head_readiness.py",
+        "exit_code": 0,
+        "result": "9 passed"
+      },
+      {
+        "command": "packet schema",
+        "exit_code": 0,
+        "result": "valid"
+      },
+      {
+        "command": "exact_head_readiness demo on 0017 proof",
+        "exit_code": 1,
+        "result": "BLOCKED as expected (skipped audit + acceptance)"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Trusted embedded audit",
+        "reason": "local-only",
+        "mitigation": "SKIPPED status correctly blocks READY"
+      },
+      {
+        "command": "Branch protection mutation",
+        "reason": "forbidden",
+        "mitigation": "not performed"
+      }
+    ]
+  },
+  "local_agy_review": {
+    "status": "NOT_RUN",
+    "ci_trust_status": "NOT_ACCEPTED"
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0018/AUDITOR_REPORT.md",
+    "findings": [],
+    "skip_reason": "No trusted runner/Claude audit route; evaluator itself treats SKIPPED as non-READY.",
+    "fixes_applied": [
+      "exact_head_readiness pure evaluator + CLI",
+      "Negative unit fixtures for all major blockers",
+      "Demo MERGE_READINESS.json BLOCKED against incomplete series proof"
+    ],
+    "remaining_risks": [
+      "Trusted embedded audit still unavailable for series READY",
+      "Vendor live acceptance still incomplete (0017)"
+    ]
+  },
+  "residual_risks": [
+    "Production multi-provider exposure still not READY",
+    "Generated .claude/claude_config.json left unstaged"
+  ],
+  "rollback": "Revert TP-0018 commits",
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Trusted audit SKIPPED; series production READY not claimed"
+  }
+}

--- a/proof/TP-DCP-MCP-RO-0018/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0018/PROOF.json
@@ -93,7 +93,10 @@
   ],
   "rollback": "Revert TP-0018 commits",
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Trusted audit SKIPPED; series production READY not claimed"
-  }
+    "number": 1066,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1066",
+    "blocker": "Trusted audit SKIPPED; series production READY not claimed (evaluator correctly BLOCKs incomplete proofs)"
+  },
+  "implementation_commit": "e843a3ebb"
 }

--- a/proof/TP-DCP-MCP-RO-0018/fixture_checks.json
+++ b/proof/TP-DCP-MCP-RO-0018/fixture_checks.json
@@ -1,0 +1,11 @@
+{
+  "checks": [
+    {
+      "name": "Unit Tests",
+      "status": "completed",
+      "conclusion": "success",
+      "head_sha": "8eee4e029208cf006dc8116a573953445d2b0841",
+      "matches_head_sha": true
+    }
+  ]
+}

--- a/scripts/audit/exact_head_readiness.py
+++ b/scripts/audit/exact_head_readiness.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI wrapper for exact-head readiness (TP-DCP-MCP-RO-0018)."""
+from __future__ import annotations
+
+from dopemux.audit.exact_head_readiness import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dopemux/audit/__init__.py
+++ b/src/dopemux/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Dopemux audit helpers."""

--- a/src/dopemux/audit/exact_head_readiness.py
+++ b/src/dopemux/audit/exact_head_readiness.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Exact-head proof/readiness evaluator (TP-DCP-MCP-RO-0018).
+
+Fail-closed local evaluator. Does not mutate branch protection, auto-merge, or
+embedded-audit routing. Inputs are JSON snapshots (or empty defaults) so tests
+and offline runs remain hermetic.
+
+READY only when all of the following hold:
+- proof head matches requested head
+- embedded audit status is PASS or PASS_WITH_RISKS (not SKIPPED/FAIL/missing)
+- no failed/pending required checks for this head
+- checks are not stale relative to head
+- no unknown reviewers/bots
+- no unresolved blocking review threads
+- changed files stay within allowlist (when provided)
+- no unclassified review items (when review classifications provided)
+- optional acceptance_report.release_ready is true when present and required
+
+Exit codes:
+  0  evaluation completed and status == READY
+  1  evaluation completed and status != READY
+  2  input/usage error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+PASSING_AUDIT = frozenset({"PASS", "PASS_WITH_RISKS"})
+FAIL_CHECK_CONCLUSIONS = frozenset(
+    {"failure", "cancelled", "timed_out", "action_required", "startup_failure"}
+)
+PENDING_CHECK_STATUS = frozenset({"queued", "in_progress", "pending", "waiting", "requested"})
+KNOWN_ACTORS_DEFAULT = frozenset(
+    {
+        "hu3mann",
+        "copilot-pull-request-reviewer",
+        "copilot-pull-request-reviewer[bot]",
+        "chatgpt-codex-connector",
+        "chatgpt-codex-connector[bot]",
+        "github-actions",
+        "github-actions[bot]",
+        "dependabot",
+        "dependabot[bot]",
+    }
+)
+
+
+def _load_json(path: Optional[Path]) -> dict[str, Any]:
+    if path is None:
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        raise SystemExit(f"unreadable json: {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise SystemExit(f"json root must be object: {path}")
+    return raw
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def evaluate_exact_head_readiness(
+    *,
+    head_sha: str,
+    pr_number: int = 0,
+    repo: str = "DDD-Enterprises/dopemux-mvp",
+    branch: str = "",
+    base_branch: str = "main",
+    proof: Optional[Mapping[str, Any]] = None,
+    checks: Optional[Iterable[Mapping[str, Any]]] = None,
+    review_threads: Optional[Iterable[Mapping[str, Any]]] = None,
+    reviewers: Optional[Iterable[str]] = None,
+    changed_files: Optional[Iterable[str]] = None,
+    allowlist: Optional[Iterable[str]] = None,
+    acceptance_report: Optional[Mapping[str, Any]] = None,
+    require_acceptance_ready: bool = False,
+    known_actors: Optional[Iterable[str]] = None,
+    created_at: Optional[str] = None,
+) -> dict[str, Any]:
+    """Pure evaluation. Never network. Fail closed on missing critical fields."""
+    head = (head_sha or "").strip()
+    blockers: list[str] = []
+    proof = dict(proof or {})
+    checks_list = [dict(c) for c in (checks or [])]
+    threads = [dict(t) for t in (review_threads or [])]
+    reviewer_list = [str(r) for r in (reviewers or [])]
+    files = [str(f) for f in (changed_files or [])]
+    allow = [str(a) for a in (allowlist or [])]
+    known = set(known_actors or KNOWN_ACTORS_DEFAULT)
+    acceptance_report = dict(acceptance_report or {})
+
+    if not head or len(head) < 7:
+        blockers.append("missing_or_short_head_sha")
+
+    # --- proof stale / head bind ---
+    proof_heads = []
+    for key in (
+        "implementation_commit",
+        "head_sha",
+        "head_at_creation",
+    ):
+        val = proof.get(key)
+        if isinstance(val, str) and val:
+            proof_heads.append(val)
+    pr_obj = proof.get("pr") if isinstance(proof.get("pr"), dict) else {}
+    for key in ("head_at_creation", "head_sha"):
+        val = pr_obj.get(key)
+        if isinstance(val, str) and val:
+            proof_heads.append(val)
+    # Also accept nested live_acceptance binding
+    live = proof.get("live_acceptance") if isinstance(proof.get("live_acceptance"), dict) else {}
+
+    proof_stale = False
+    if head and proof_heads:
+        # Any explicit head field must match (prefix-ok)
+        for ph in proof_heads:
+            if not (head.startswith(ph) or ph.startswith(head[:7])):
+                proof_stale = True
+                break
+    elif head and proof:
+        # Proof present but no head bind → stale/unknown
+        proof_stale = True
+        blockers.append("proof_missing_head_bind")
+    if proof_stale:
+        blockers.append("proof_stale_to_head")
+
+    # --- embedded audit ---
+    emb = proof.get("embedded_audit") if isinstance(proof.get("embedded_audit"), dict) else {}
+    audit_status = str(emb.get("status") or proof.get("audit_status") or "").upper()
+    if not audit_status:
+        blockers.append("embedded_audit_missing")
+    elif audit_status in {"SKIPPED", "FAIL", "FAILED", "ERROR", "NOT_RUN"}:
+        blockers.append(f"embedded_audit_{audit_status.lower()}")
+    elif audit_status not in PASSING_AUDIT:
+        blockers.append(f"embedded_audit_not_passing:{audit_status or 'unknown'}")
+
+    # --- checks ---
+    failed_checks: list[str] = []
+    pending_checks: list[str] = []
+    checks_stale = False
+    if not checks_list:
+        blockers.append("checks_missing")
+    for check in checks_list:
+        name = str(check.get("name") or "unknown-check")
+        status = str(check.get("status") or "unknown").lower()
+        conclusion = str(check.get("conclusion") or "unknown").lower()
+        check_head = str(check.get("head_sha") or "")
+        matches = check.get("matches_head_sha")
+        if matches is None and head and check_head:
+            matches = head.startswith(check_head) or check_head.startswith(head[:7])
+        if head and check_head and not matches:
+            checks_stale = True
+        if status in PENDING_CHECK_STATUS or conclusion == "pending":
+            pending_checks.append(name)
+        if status == "completed" and conclusion in FAIL_CHECK_CONCLUSIONS:
+            failed_checks.append(name)
+        if status == "completed" and conclusion not in {
+            "success",
+            "skipped",
+            "neutral",
+            "cancelled",  # cancelled still listed below as fail-ish for required
+        }:
+            # non-success completed (except skipped/neutral) blocks
+            if conclusion not in {"success", "skipped", "neutral"}:
+                if name not in failed_checks and conclusion in FAIL_CHECK_CONCLUSIONS:
+                    pass
+    if failed_checks:
+        blockers.append("failed_checks")
+    if pending_checks:
+        blockers.append("pending_checks")
+    if checks_stale:
+        blockers.append("checks_stale_to_head")
+
+    # --- unknown reviewers ---
+    unknown_reviewers = sorted({r for r in reviewer_list if r and r not in known and r.rstrip("]") not in known})
+    # normalize bot suffix
+    cleaned_unknown = []
+    for r in unknown_reviewers:
+        base = r.replace("[bot]", "")
+        if base in known or r in known:
+            continue
+        cleaned_unknown.append(r)
+    unknown_reviewers = cleaned_unknown
+    if unknown_reviewers:
+        blockers.append("unknown_reviewers_or_bots")
+
+    # --- unresolved threads ---
+    blocking_thread_unresolved = False
+    for thread in threads:
+        if thread.get("isResolved") is True:
+            continue
+        # treat unresolved as blocking unless explicitly non-blocking
+        if thread.get("blocking") is False:
+            continue
+        blocking_thread_unresolved = True
+        break
+    if blocking_thread_unresolved:
+        blockers.append("blocking_thread_unresolved")
+
+    # --- allowlist scope escape ---
+    diff_escapes = False
+    if allow and files:
+        for path in files:
+            if path == ".claude/claude_config.json":
+                # generated noise; still counts as escape if present in changed set
+                # for readiness we block unallowlisted paths
+                pass
+            if not _path_allowed(path, allow):
+                diff_escapes = True
+                break
+    if diff_escapes:
+        blockers.append("diff_escapes_packet_allowlist")
+
+    # --- acceptance release_ready optional gate ---
+    if require_acceptance_ready:
+        if acceptance_report.get("release_ready") is not True:
+            blockers.append("acceptance_release_not_ready")
+        # Also inspect proof nested field
+        if live.get("release_ready") is False:
+            if "acceptance_release_not_ready" not in blockers:
+                blockers.append("acceptance_release_not_ready")
+
+    # Dedupe blockers preserve order
+    seen: set[str] = set()
+    ordered_blockers: list[str] = []
+    for b in blockers:
+        if b not in seen:
+            seen.add(b)
+            ordered_blockers.append(b)
+
+    status = "READY" if not ordered_blockers else "BLOCKED"
+    created = created_at or datetime.now(timezone.utc).isoformat()
+
+    return {
+        "schema_version": "1.0.0",
+        "evaluator": "scripts/audit/exact_head_readiness.py",
+        "packet_series": "TP-DCP-MCP-RO-0018",
+        "pr_number": pr_number,
+        "repo": repo,
+        "branch": branch,
+        "head_sha": head,
+        "base_branch": base_branch,
+        "changed_files": files,
+        "checks": [
+            {
+                "name": str(c.get("name") or "unknown"),
+                "status": str(c.get("status") or "unknown"),
+                "conclusion": str(c.get("conclusion") or "unknown"),
+                "head_sha": str(c.get("head_sha") or ""),
+                "matches_head_sha": bool(
+                    c.get("matches_head_sha")
+                    if c.get("matches_head_sha") is not None
+                    else (
+                        head
+                        and c.get("head_sha")
+                        and (
+                            head.startswith(str(c.get("head_sha")))
+                            or str(c.get("head_sha")).startswith(head[:7])
+                        )
+                    )
+                ),
+            }
+            for c in checks_list
+        ],
+        "review_threads": threads,
+        "unknown_reviewers_or_bots": unknown_reviewers,
+        "failed_checks": failed_checks,
+        "pending_checks": pending_checks,
+        "checks_stale_to_head": checks_stale,
+        "proof_stale": proof_stale,
+        "blocking_thread_unresolved": blocking_thread_unresolved,
+        "diff_escapes_packet_allowlist": diff_escapes,
+        "embedded_audit_status": audit_status or "MISSING",
+        "unresolved_blockers": ordered_blockers,
+        "status": status,
+        "ready_for_merge": status == "READY",
+        "created_at": created,
+        "proof_bundle_refs": [str(p) for p in _as_list(proof.get("files_changed"))][:20]
+        if proof
+        else [],
+        "notes": [
+            "READY requires embedded audit PASS/PASS_WITH_RISKS; SKIPPED fails closed.",
+            "Does not change branch protection or embedded-audit.yml routing.",
+            "Skipped live acceptance keeps require_acceptance_ready blocked when enabled.",
+        ],
+    }
+
+
+def _path_allowed(path: str, allowlist: Iterable[str]) -> bool:
+    for pattern in allowlist:
+        if pattern.endswith("/**"):
+            root = pattern[:-3]
+            if path == root.rstrip("/") or path.startswith(root.rstrip("/") + "/"):
+                return True
+        elif pattern.endswith("/*"):
+            root = pattern[:-2]
+            if path.startswith(root.rstrip("/") + "/") and "/" not in path[len(root.rstrip("/")) + 1 :]:
+                return True
+        elif path == pattern:
+            return True
+        elif path.startswith(pattern.rstrip("/") + "/"):
+            # directory prefix without glob
+            if pattern.endswith("/"):
+                return True
+    return False
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--head-sha", required=True)
+    p.add_argument("--pr-number", type=int, default=0)
+    p.add_argument("--repo", default="DDD-Enterprises/dopemux-mvp")
+    p.add_argument("--branch", default="")
+    p.add_argument("--base-branch", default="main")
+    p.add_argument("--proof-json", type=Path, default=None)
+    p.add_argument("--checks-json", type=Path, default=None, help="JSON list or {checks:[...]}")
+    p.add_argument("--threads-json", type=Path, default=None, help="JSON list or {threads:[...]}")
+    p.add_argument("--reviewers-json", type=Path, default=None, help="JSON list of logins")
+    p.add_argument("--changed-files-json", type=Path, default=None)
+    p.add_argument("--allowlist-json", type=Path, default=None)
+    p.add_argument("--acceptance-json", type=Path, default=None)
+    p.add_argument("--require-acceptance-ready", action="store_true")
+    p.add_argument("--out", type=Path, default=None)
+    return p
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    proof = _load_json(args.proof_json)
+    checks_raw = _load_json(args.checks_json) if args.checks_json else {}
+    if isinstance(checks_raw, dict) and "checks" in checks_raw:
+        checks = checks_raw.get("checks") or []
+    elif isinstance(checks_raw, list):
+        checks = checks_raw
+    else:
+        checks = _as_list(checks_raw.get("checks")) if checks_raw else []
+
+    threads_raw = _load_json(args.threads_json) if args.threads_json else {}
+    if isinstance(threads_raw, dict):
+        threads = threads_raw.get("threads") or threads_raw.get("review_threads") or []
+    else:
+        threads = []
+
+    reviewers_raw = json.loads(args.reviewers_json.read_text()) if args.reviewers_json else []
+    if isinstance(reviewers_raw, dict):
+        reviewers = reviewers_raw.get("reviewers") or []
+    else:
+        reviewers = reviewers_raw if isinstance(reviewers_raw, list) else []
+
+    files_raw = json.loads(args.changed_files_json.read_text()) if args.changed_files_json else []
+    if isinstance(files_raw, dict):
+        files = files_raw.get("files") or files_raw.get("changed_files") or []
+    else:
+        files = files_raw if isinstance(files_raw, list) else []
+
+    allow_raw = json.loads(args.allowlist_json.read_text()) if args.allowlist_json else []
+    if isinstance(allow_raw, dict):
+        allow = allow_raw.get("allowlist") or []
+    else:
+        allow = allow_raw if isinstance(allow_raw, list) else []
+
+    acceptance = _load_json(args.acceptance_json) if args.acceptance_json else {}
+
+    result = evaluate_exact_head_readiness(
+        head_sha=args.head_sha,
+        pr_number=args.pr_number,
+        repo=args.repo,
+        branch=args.branch,
+        base_branch=args.base_branch,
+        proof=proof,
+        checks=checks,
+        review_threads=threads,
+        reviewers=reviewers,
+        changed_files=files,
+        allowlist=allow,
+        acceptance_report=acceptance,
+        require_acceptance_ready=args.require_acceptance_ready,
+    )
+    text = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0 if result["status"] == "READY" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -140,6 +140,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0015 | DCP / MCP | Ownership Verification And Release-One Adapters | Active | TP-DCP-MCP-RO-0014 |
 | TP-DCP-MCP-RO-0016 | DCP / MCP | Multi-Provider Setup And Rollback Docs | Active | TP-DCP-MCP-RO-0015 |
 | TP-DCP-MCP-RO-0017 | DCP / MCP | Acceptance Matrix And Fail-Closed Harness | Active | TP-DCP-MCP-RO-0016 |
+| TP-DCP-MCP-RO-0018 | DCP / MCP | Exact-Head Proof Readiness Evaluator | Active | TP-DCP-MCP-RO-0017 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.json
@@ -1,0 +1,86 @@
+{
+  "id": "TP-DCP-MCP-RO-0018",
+  "project": "dopemux-mvp",
+  "target": "Add a fail-closed exact-head proof/readiness evaluator that blocks READY on stale proof, skipped audit, failed/pending/stale checks, unknown reviewers, unresolved threads, allowlist escape, and incomplete acceptance without mutating branch protection or embedded-audit routing.",
+  "invariants": [
+    "READY requires proof head bind to the evaluated SHA.",
+    "SKIPPED embedded audit never yields READY.",
+    "Failed or pending checks block READY.",
+    "Stale checks relative to head block READY.",
+    "Unknown reviewers/bots and unresolved blocking threads block READY.",
+    "Allowlist escapes block READY.",
+    "No branch protection, auto-merge, or embedded-audit.yml routing changes."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0017"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0017",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0018-proof-readiness",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0017 acceptance harness is merged on main (PR #1065)."
+  },
+  "commit": {
+    "message": "feat(audit): add exact-head proof readiness evaluator",
+    "allowlist": [
+      "src/dopemux/audit/exact_head_readiness.py",
+      "src/dopemux/audit/__init__.py",
+      "scripts/audit/exact_head_readiness.py",
+      "tests/audit/test_exact_head_readiness.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/EXACT_HEAD_READINESS.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0018/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q tests/audit/test_exact_head_readiness.py",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(audit): add exact-head proof readiness evaluator",
+    "body": "Implements TP-DCP-MCP-RO-0018: fail-closed exact-head readiness evaluator with negative fixtures. Does not change branch protection or embedded-audit routing. SKIPPED audit and incomplete acceptance keep status BLOCKED.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "evaluator",
+      "task": "Implement pure exact-head readiness evaluation and CLI wrapper.",
+      "validation": [
+        "Unit tests cover stale proof, skipped audit, failed/pending/stale checks, unknown reviewers, threads, allowlist escape, acceptance gate."
+      ]
+    },
+    {
+      "id": "docs-proof",
+      "task": "Document evaluator, register packet, emit proof including negative MERGE_READINESS fixture run.",
+      "validation": [
+        "Proof records that production series READY still requires trusted audit and full live acceptance."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0018.md
@@ -1,0 +1,37 @@
+---
+id: TP-DCP-MCP-RO-0018
+title: Exact-Head Proof Readiness Evaluator
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Fail-closed exact-head readiness evaluation for the DCP multi-provider series final governance packet.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0018
+
+## Objective
+
+Bind proof/readiness evaluation to an exact head SHA and fail closed on stale
+proof, skipped audit, bad/pending checks, unknown reviewers, unresolved
+threads, and allowlist escapes — without changing branch protection or
+embedded-audit routing.
+
+## Scope
+
+IN: evaluator library + CLI, negative unit tests, docs, packet/proof.
+
+OUT: branch protection edits, auto-merge, secrets, auditor route changes,
+claiming series production READY without trusted audit + full live acceptance.
+
+## Validation
+
+```text
+uv run --frozen pytest -q tests/audit/test_exact_head_readiness.py
+uv run --frozen python scripts/audit/exact_head_readiness.py --help
+```
+
+## Rollback
+
+Revert TP-0018 commits. Existing PR Steward artifacts remain independently usable.

--- a/tests/audit/test_exact_head_readiness.py
+++ b/tests/audit/test_exact_head_readiness.py
@@ -1,0 +1,170 @@
+"""Negative/positive fixtures for exact-head readiness (TP-0018)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dopemux.audit.exact_head_readiness import evaluate_exact_head_readiness
+
+
+HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def _ok_proof(**over):
+    base = {
+        "implementation_commit": HEAD,
+        "embedded_audit": {"status": "PASS", "report_path": "proof/x/AUDITOR_REPORT.md"},
+        "pr": {"head_at_creation": HEAD},
+    }
+    base.update(over)
+    return base
+
+
+def _ok_checks():
+    return [
+        {
+            "name": "Unit Tests",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": HEAD,
+            "matches_head_sha": True,
+        }
+    ]
+
+
+def test_ready_when_all_gates_green():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(),
+        checks=_ok_checks(),
+        review_threads=[{"isResolved": True}],
+        reviewers=["hu3mann"],
+        changed_files=["services/dcp-readonly-facade/src/dcp_facade/acceptance.py"],
+        allowlist=["services/dcp-readonly-facade/src/dcp_facade/**"],
+    )
+    assert result["status"] == "READY"
+    assert result["ready_for_merge"] is True
+    assert result["unresolved_blockers"] == []
+
+
+def test_stale_proof_blocks():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(implementation_commit="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        checks=_ok_checks(),
+    )
+    assert result["status"] == "BLOCKED"
+    assert "proof_stale_to_head" in result["unresolved_blockers"]
+
+
+def test_skipped_audit_blocks():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(embedded_audit={"status": "SKIPPED"}),
+        checks=_ok_checks(),
+    )
+    assert result["status"] == "BLOCKED"
+    assert any("embedded_audit_skipped" == b for b in result["unresolved_blockers"])
+
+
+def test_failed_and_pending_checks_block():
+    checks = [
+        {
+            "name": "Unit Tests",
+            "status": "completed",
+            "conclusion": "failure",
+            "head_sha": HEAD,
+            "matches_head_sha": True,
+        },
+        {
+            "name": "preflight",
+            "status": "in_progress",
+            "conclusion": "pending",
+            "head_sha": HEAD,
+            "matches_head_sha": True,
+        },
+    ]
+    result = evaluate_exact_head_readiness(head_sha=HEAD, proof=_ok_proof(), checks=checks)
+    assert result["status"] == "BLOCKED"
+    assert "failed_checks" in result["unresolved_blockers"]
+    assert "pending_checks" in result["unresolved_blockers"]
+
+
+def test_stale_checks_block():
+    checks = [
+        {
+            "name": "Unit Tests",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "matches_head_sha": False,
+        }
+    ]
+    result = evaluate_exact_head_readiness(head_sha=HEAD, proof=_ok_proof(), checks=checks)
+    assert result["status"] == "BLOCKED"
+    assert "checks_stale_to_head" in result["unresolved_blockers"]
+
+
+def test_unknown_reviewer_and_unresolved_thread_block():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(),
+        checks=_ok_checks(),
+        reviewers=["mystery-bot"],
+        review_threads=[{"isResolved": False, "path": "x.py"}],
+    )
+    assert result["status"] == "BLOCKED"
+    assert "unknown_reviewers_or_bots" in result["unresolved_blockers"]
+    assert "blocking_thread_unresolved" in result["unresolved_blockers"]
+
+
+def test_allowlist_escape_blocks():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(),
+        checks=_ok_checks(),
+        changed_files=["secrets/prod.env", "services/dcp-readonly-facade/src/dcp_facade/x.py"],
+        allowlist=["services/dcp-readonly-facade/src/dcp_facade/**"],
+    )
+    assert result["status"] == "BLOCKED"
+    assert "diff_escapes_packet_allowlist" in result["unresolved_blockers"]
+
+
+def test_acceptance_not_ready_blocks_when_required():
+    result = evaluate_exact_head_readiness(
+        head_sha=HEAD,
+        proof=_ok_proof(),
+        checks=_ok_checks(),
+        acceptance_report={"release_ready": False},
+        require_acceptance_ready=True,
+    )
+    assert result["status"] == "BLOCKED"
+    assert "acceptance_release_not_ready" in result["unresolved_blockers"]
+
+
+def test_cli_writes_blocked_artifact(tmp_path: Path):
+    from dopemux.audit.exact_head_readiness import main
+
+    proof = tmp_path / "PROOF.json"
+    proof.write_text(json.dumps(_ok_proof(embedded_audit={"status": "SKIPPED"})))
+    checks = tmp_path / "checks.json"
+    checks.write_text(json.dumps({"checks": _ok_checks()}))
+    out = tmp_path / "MERGE_READINESS.json"
+    code = main(
+        [
+            "--head-sha",
+            HEAD,
+            "--proof-json",
+            str(proof),
+            "--checks-json",
+            str(checks),
+            "--out",
+            str(out),
+        ]
+    )
+    assert code == 1
+    payload = json.loads(out.read_text())
+    assert payload["status"] == "BLOCKED"


### PR DESCRIPTION
## Summary

Implements **TP-DCP-MCP-RO-0018** (series final governance packet) on merged TP-0017 (#1065).

- Pure exact-head readiness evaluator (`dopemux.audit.exact_head_readiness`)
- CLI: `scripts/audit/exact_head_readiness.py`
- Negative unit fixtures for all major blockers
- Demo `MERGE_READINESS.json` correctly **BLOCKED** against incomplete 0017 proof (skipped audit + acceptance not ready)

## Explicit non-changes

- No branch protection mutation
- No auto-merge enablement
- No `embedded-audit.yml` / auditor routing changes
- Does **not** claim multi-provider production READY

## Validation

- `pytest tests/audit/test_exact_head_readiness.py` — 9 passed
- Demo evaluation exit 1 / status BLOCKED (expected)

## Series note

Code path 0012–0017 is on main for local/local-live. Production READY still needs trusted embedded audit PASS and full live acceptance (`release_ready=true`).