### PR TITLE
feat(dcp): vendor-live preflight and two-target isolation

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/VENDOR_LIVE_PREFLIGHT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/VENDOR_LIVE_PREFLIGHT.md
@@ -1,0 +1,86 @@
+---
+id: dcp-mcp-readonly-vendor-live-preflight
+title: DCP Vendor-Live Acceptance Preflight
+type: how-to
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Credential and tool inventory for finishing DCP-ACC-024/025/026 vendor live gates without inventing secrets or opening unauthorized public tunnels.
+---
+
+# Vendor-Live Acceptance Preflight
+
+Extends TP-0017 for residual track **vendor-live**.
+
+## What this environment can do without vendor secrets
+
+| Gate | Capability without vendor creds |
+| --- | --- |
+| DCP-ACC-029 | **PASS** via synthetic two-target isolation |
+| DCP-ACC-024/025/026 | **NOT_RUN** with explicit missing inventory |
+
+The harness **never** invents OpenAI/Grok/Gemini credentials and **never** opens a
+public quick tunnel automatically (unrestricted public exposure is forbidden).
+
+## Required inventory
+
+### Shared
+
+```text
+export DCP_ACCEPTANCE_LIVE=1
+export DCP_ACCEPTANCE_LIVE_TOKEN='<connector-bearer-from-secret-store>'
+export DCP_ACCEPTANCE_LIVE_PROVIDERS=local,chatgpt,grok,gemini
+```
+
+### ChatGPT (DCP-ACC-024)
+
+| Need | Purpose |
+| --- | --- |
+| `tunnel-client` binary | OpenAI Secure MCP Tunnel |
+| `CONTROL_PLANE_API_KEY` | Tunnel runtime API key |
+| `OPENAI_TUNNEL_ID` | Tunnel id (never commit) |
+| `OPENAI_TUNNEL_PROFILE` | Optional profile name |
+| Loopback facade running | `DCP_FACADE_TRANSPORT=streamable-http` on 127.0.0.1 |
+
+### Grok (DCP-ACC-025)
+
+| Need | Purpose |
+| --- | --- |
+| `PUBLIC_GROK_HOSTNAME` | Stable named HTTPS host |
+| Named Cloudflare/ngrok tunnel to loopback facade | Restart-stable route |
+| Grok connector bearer | Separate from ChatGPT |
+
+### Gemini (DCP-ACC-026)
+
+| Need | Purpose |
+| --- | --- |
+| `PUBLIC_GEMINI_HOSTNAME` | Remote MCP URL host |
+| Gemini project/API access | Unsupported transport fail-closed proof |
+
+## Commands
+
+```bash
+# Preflight inventory (no secrets printed)
+uv run --frozen python -c 'from dcp_facade.acceptance import vendor_preflight; import json; print(json.dumps(vendor_preflight(), indent=2))'
+
+# Local + vendor-track (vendor gates stay NOT_RUN until inventory complete)
+export DCP_ACCEPTANCE_LIVE=1
+export DCP_ACCEPTANCE_LIVE_TOKEN='...'
+export DCP_ACCEPTANCE_LIVE_PROVIDERS=local,chatgpt,grok,gemini
+PYTHONPATH=services/dcp-readonly-facade/src uv run --frozen python -m dcp_facade.acceptance
+```
+
+## Manual vendor receipt attachments (when inventory complete)
+
+For each enabled provider, attach **redacted** evidence under an operator-owned
+path (not secrets):
+
+1. Tool discovery export / screenshot (no tokens)
+2. Tunnel doctor status (ChatGPT) or DNS/HTTPS check (Grok)
+3. Denied-tool and unauthorized-target attempts
+4. Credential revoke/retry (old fails, new works)
+5. Disconnect/restart proof
+
+Then re-run exact-head readiness with trusted audit.

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/AUDITOR_REPORT.md
@@ -1,0 +1,6 @@
+# Auditor Report: TP-DCP-MCP-RO-0017-VENDOR
+
+Trusted embedded audit: SKIPPED (local-only).
+
+Vendor-live cannot complete without operator-supplied credentials. Preflight
+records exact missing inventory. No secrets captured.

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/COMMAND_LOG.md
@@ -1,0 +1,10 @@
+# TP-DCP-MCP-RO-0017-VENDOR Command Log
+
+| Command | Result |
+| --- | --- |
+| Residual track 1 (vendor-live) selected | YES |
+| Vendor credentials inventory | MISSING (see vendor_preflight.json) |
+| tunnel-client | ABSENT |
+| cloudflared | PRESENT (not auto-used; no unrestricted public tunnel) |
+| Local+vendor providers acceptance run | release_ready=false; 029 PASS; 024-026 NOT_RUN |
+| Public tunnel open | NOT_RUN (forbidden without named host + credentials) |

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/PROOF.json
@@ -79,7 +79,10 @@
     ]
   },
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Vendor credentials missing; release_ready false"
-  }
+    "number": 1067,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1067",
+    "blocker": "Vendor credentials missing; release_ready false; trusted audit SKIPPED"
+  },
+  "implementation_commit": "20e9dae3e3b7471b289a0c81a1e7b75dfac0f980"
 }

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/PROOF.json
@@ -1,0 +1,85 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0017-VENDOR",
+  "title": "Vendor-Live Preflight And Two-Target Isolation",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0017-vendor-live",
+  "base_branch": "main",
+  "base_sha": "0a2efa25138ff748948cea75d295fcd2afb3a7ce",
+  "scope": "Vendor-live residual: preflight inventory, ACC-029 synthetic isolation PASS, ACC-024/025/026 NOT_RUN without credentials. No public tunnels opened.",
+  "vendor_live": {
+    "release_ready": false,
+    "blocking_live_not_run": 3,
+    "blocking_failures": 0,
+    "acc029": "PASS",
+    "acc024_025_026": "NOT_RUN",
+    "missing": [
+      "tunnel-client",
+      "CONTROL_PLANE_API_KEY",
+      "OPENAI_TUNNEL_ID",
+      "PUBLIC_GROK_HOSTNAME",
+      "PUBLIC_GEMINI_HOSTNAME"
+    ]
+  },
+  "validation": {
+    "PASS": [
+      {
+        "command": "acceptance harness tests",
+        "exit_code": 0,
+        "result": "8 passed"
+      },
+      {
+        "command": "full facade suite",
+        "exit_code": 0,
+        "result": "passed"
+      },
+      {
+        "command": "vendor-track acceptance report",
+        "exit_code": 0,
+        "result": "029 PASS; 024-026 NOT_RUN; release_ready false"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "ChatGPT tunnel-client live",
+        "reason": "tunnel-client + OpenAI tunnel env missing",
+        "mitigation": "see VENDOR_LIVE_PREFLIGHT.md"
+      },
+      {
+        "command": "Grok/Gemini public routes",
+        "reason": "PUBLIC_*_HOSTNAME missing",
+        "mitigation": "operator supply"
+      },
+      {
+        "command": "Trusted embedded audit",
+        "reason": "local-only",
+        "mitigation": "not claimed"
+      }
+    ]
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0017-VENDOR/AUDITOR_REPORT.md",
+    "findings": [],
+    "skip_reason": "Local-only; AGY not used as trusted audit.",
+    "fixes_applied": [
+      "vendor_preflight inventory",
+      "ACC-029 synthetic two-target isolation",
+      "vendor gate NOT_RUN with explicit missing list"
+    ],
+    "remaining_risks": [
+      "Vendor credentials still required for 024-026",
+      "release_ready remains false"
+    ]
+  },
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Vendor credentials missing; release_ready false"
+  }
+}

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/acceptance_report.json
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/acceptance_report.json
@@ -1,0 +1,390 @@
+{
+  "blocking_failures": 0,
+  "blocking_live_not_run": 3,
+  "deterministic_count": 12,
+  "generated_at": "2026-07-17T00:30:55.362060+00:00",
+  "live_authorized": true,
+  "live_count": 13,
+  "note": "release_ready is true only when every blocking gate PASSes. Live NOT_RUN keeps release_ready false.",
+  "release_ready": false,
+  "rollup": [
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "unknown target blocked with generic reason",
+          "evidence": {
+            "public_reason": "target not authorized"
+          },
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-001"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-001"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "port-only ownership rejected without labels/identity",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-006"
+        },
+        {
+          "blocking": true,
+          "detail": "ownership verifies only with full evidence; port alone insufficient (covered by matrix tests)",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-006"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-006"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "stale candidate blocked",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-008"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-008"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "wrong project identity blocked",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-009"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-009"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "ambiguous candidates blocked",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-010"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-010"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "dope_context not in release-one operations",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-012"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-012"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "connector allows only authorized target/tool; others blocked",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-013"
+        },
+        {
+          "blocking": true,
+          "detail": "second connector authenticates independently on same ingress",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-013"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-013"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "get_progress not in release-one allowlist",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-014"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-014"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "release-one allowlist excludes mutation-shaped denied ops",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-015"
+        },
+        {
+          "blocking": true,
+          "detail": "health ok without tool disclosure; bind is loopback",
+          "evidence": {
+            "bind": "127.0.0.1:56314"
+          },
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-015"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-015"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "progress side-effect path denied without adapter call",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-016"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-016"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "no policy mutation path; denied op stays denied under injection-style names",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-017"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-017"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "audit dump excludes raw bearer token values",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-020"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-020"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "unauthenticated MCP denied; no tool list",
+          "evidence": {
+            "status": 401
+          },
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-021"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-021"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "concurrency limit enforced",
+          "evidence": {},
+          "gate_type": "deterministic",
+          "status": "PASS",
+          "test_id": "DCP-ACC-022"
+        },
+        {
+          "blocking": true,
+          "detail": "burst exhaustion returns 429 on live loopback",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-022"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-022"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "local connector discovery returns non-mutation tool subset only",
+          "evidence": {
+            "tool_count": 2
+          },
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-023"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-023"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "ChatGPT tunnel not runnable: need tunnel-client + CONTROL_PLANE_API_KEY + OPENAI_TUNNEL_ID + connector token. vendor preflight: missing=install tunnel-client (OpenAI Secure MCP Tunnel),set CONTROL_PLANE_API_KEY,set OPENAI_TUNNEL_ID,set PUBLIC_GROK_HOSTNAME (stable named tunnel host),set PUBLIC_GEMINI_HOSTNAME",
+          "evidence": {
+            "env_present": {
+              "CONTROL_PLANE_API_KEY": false,
+              "DCP_ACCEPTANCE_LIVE_TOKEN": true,
+              "GEMINI_API_KEY": false,
+              "OPENAI_API_KEY": false,
+              "OPENAI_TUNNEL_ID": false,
+              "OPENAI_TUNNEL_PROFILE": false,
+              "PUBLIC_GEMINI_HOSTNAME": false,
+              "PUBLIC_GROK_HOSTNAME": false,
+              "XAI_API_KEY": false
+            },
+            "tools": {
+              "cloudflared": true,
+              "curl": true,
+              "ngrok": false,
+              "tunnel-client": false
+            }
+          },
+          "gate_type": "live",
+          "status": "NOT_RUN",
+          "test_id": "DCP-ACC-024"
+        }
+      ],
+      "status": "NOT_RUN",
+      "test_id": "DCP-ACC-024"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "Grok stable route not runnable: need PUBLIC_GROK_HOSTNAME + connector token. vendor preflight: missing=install tunnel-client (OpenAI Secure MCP Tunnel),set CONTROL_PLANE_API_KEY,set OPENAI_TUNNEL_ID,set PUBLIC_GROK_HOSTNAME (stable named tunnel host),set PUBLIC_GEMINI_HOSTNAME",
+          "evidence": {
+            "env_present": {
+              "CONTROL_PLANE_API_KEY": false,
+              "DCP_ACCEPTANCE_LIVE_TOKEN": true,
+              "GEMINI_API_KEY": false,
+              "OPENAI_API_KEY": false,
+              "OPENAI_TUNNEL_ID": false,
+              "OPENAI_TUNNEL_PROFILE": false,
+              "PUBLIC_GEMINI_HOSTNAME": false,
+              "PUBLIC_GROK_HOSTNAME": false,
+              "XAI_API_KEY": false
+            }
+          },
+          "gate_type": "live",
+          "status": "NOT_RUN",
+          "test_id": "DCP-ACC-025"
+        }
+      ],
+      "status": "NOT_RUN",
+      "test_id": "DCP-ACC-025"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "Gemini transport gate not runnable: need PUBLIC_GEMINI_HOSTNAME + connector token. vendor preflight: missing=install tunnel-client (OpenAI Secure MCP Tunnel),set CONTROL_PLANE_API_KEY,set OPENAI_TUNNEL_ID,set PUBLIC_GROK_HOSTNAME (stable named tunnel host),set PUBLIC_GEMINI_HOSTNAME",
+          "evidence": {
+            "env_present": {
+              "CONTROL_PLANE_API_KEY": false,
+              "DCP_ACCEPTANCE_LIVE_TOKEN": true,
+              "GEMINI_API_KEY": false,
+              "OPENAI_API_KEY": false,
+              "OPENAI_TUNNEL_ID": false,
+              "OPENAI_TUNNEL_PROFILE": false,
+              "PUBLIC_GEMINI_HOSTNAME": false,
+              "PUBLIC_GROK_HOSTNAME": false,
+              "XAI_API_KEY": false
+            }
+          },
+          "gate_type": "live",
+          "status": "NOT_RUN",
+          "test_id": "DCP-ACC-026"
+        }
+      ],
+      "status": "NOT_RUN",
+      "test_id": "DCP-ACC-026"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "credential rotation rejects old token; new token accepted",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-027"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-027"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "facade stop ends loopback access (local disable sequence)",
+          "evidence": {
+            "bind": "127.0.0.1:56314"
+          },
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-028"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-028"
+    },
+    {
+      "results": [
+        {
+          "blocking": true,
+          "detail": "two-target connector isolation + wrong-owner ownership block (synthetic, no vendor tunnel)",
+          "evidence": {},
+          "gate_type": "live",
+          "status": "PASS",
+          "test_id": "DCP-ACC-029"
+        }
+      ],
+      "status": "PASS",
+      "test_id": "DCP-ACC-029"
+    }
+  ]
+}

--- a/proof/TP-DCP-MCP-RO-0017-VENDOR/vendor_preflight.json
+++ b/proof/TP-DCP-MCP-RO-0017-VENDOR/vendor_preflight.json
@@ -1,0 +1,32 @@
+{
+  "tools": {
+    "tunnel-client": false,
+    "cloudflared": true,
+    "ngrok": false,
+    "curl": true
+  },
+  "env_present": {
+    "CONTROL_PLANE_API_KEY": false,
+    "OPENAI_API_KEY": false,
+    "OPENAI_TUNNEL_ID": false,
+    "OPENAI_TUNNEL_PROFILE": false,
+    "XAI_API_KEY": false,
+    "PUBLIC_GROK_HOSTNAME": false,
+    "GEMINI_API_KEY": false,
+    "PUBLIC_GEMINI_HOSTNAME": false,
+    "DCP_ACCEPTANCE_LIVE_TOKEN": false
+  },
+  "gates_runnable": {
+    "DCP-ACC-024_chatgpt_tunnel": false,
+    "DCP-ACC-025_grok_stable": false,
+    "DCP-ACC-026_gemini_transport": false
+  },
+  "missing_for_vendor_live": [
+    "install tunnel-client (OpenAI Secure MCP Tunnel)",
+    "set CONTROL_PLANE_API_KEY",
+    "set OPENAI_TUNNEL_ID",
+    "set PUBLIC_GROK_HOSTNAME (stable named tunnel host)",
+    "set PUBLIC_GEMINI_HOSTNAME",
+    "set DCP_ACCEPTANCE_LIVE_TOKEN (connector bearer)"
+  ]
+}

--- a/services/dcp-readonly-facade/src/dcp_facade/acceptance.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/acceptance.py
@@ -587,15 +587,265 @@ def run_local_loopback_live_gates(token: str) -> list[GateResult]:
     return results
 
 
-def run_live_gates() -> list[GateResult]:
-    """Live gates: fail closed without dual consent; local loopback when authorized."""
-    ok, reason = live_mode_authorized()
-    vendor_ids = [
-        "DCP-ACC-024",  # ChatGPT tunnel
-        "DCP-ACC-025",  # Grok stable
-        "DCP-ACC-026",  # unsupported transport
-        "DCP-ACC-029",  # two-worktree live isolation (needs dual backends)
+def vendor_preflight() -> dict[str, Any]:
+    """Inventory required tools/env for vendor gates without printing secrets."""
+    import shutil
+
+    def _set(name: str) -> bool:
+        v = os.getenv(name, "").strip()
+        return bool(v) and not (v.startswith("<") and v.endswith(">"))
+
+    inventory = {
+        "tools": {
+            "tunnel-client": bool(shutil.which("tunnel-client")),
+            "cloudflared": bool(shutil.which("cloudflared")),
+            "ngrok": bool(shutil.which("ngrok")),
+            "curl": bool(shutil.which("curl")),
+        },
+        "env_present": {
+            "CONTROL_PLANE_API_KEY": _set("CONTROL_PLANE_API_KEY"),
+            "OPENAI_API_KEY": _set("OPENAI_API_KEY"),
+            "OPENAI_TUNNEL_ID": _set("OPENAI_TUNNEL_ID"),
+            "OPENAI_TUNNEL_PROFILE": _set("OPENAI_TUNNEL_PROFILE"),
+            "XAI_API_KEY": _set("XAI_API_KEY") or _set("GROK_API_KEY"),
+            "PUBLIC_GROK_HOSTNAME": _set("PUBLIC_GROK_HOSTNAME"),
+            "GEMINI_API_KEY": _set("GEMINI_API_KEY") or _set("GOOGLE_API_KEY"),
+            "PUBLIC_GEMINI_HOSTNAME": _set("PUBLIC_GEMINI_HOSTNAME"),
+            "DCP_ACCEPTANCE_LIVE_TOKEN": _set(LIVE_TOKEN_ENV),
+        },
+    }
+    chatgpt_ok = (
+        inventory["tools"]["tunnel-client"]
+        and inventory["env_present"]["CONTROL_PLANE_API_KEY"]
+        and inventory["env_present"]["OPENAI_TUNNEL_ID"]
+        and inventory["env_present"]["DCP_ACCEPTANCE_LIVE_TOKEN"]
+    )
+    grok_ok = inventory["env_present"]["PUBLIC_GROK_HOSTNAME"] and inventory["env_present"][
+        "DCP_ACCEPTANCE_LIVE_TOKEN"
     ]
+    gemini_ok = inventory["env_present"]["PUBLIC_GEMINI_HOSTNAME"] and inventory["env_present"][
+        "DCP_ACCEPTANCE_LIVE_TOKEN"
+    ]
+    inventory["gates_runnable"] = {
+        "DCP-ACC-024_chatgpt_tunnel": chatgpt_ok,
+        "DCP-ACC-025_grok_stable": grok_ok,
+        "DCP-ACC-026_gemini_transport": gemini_ok,
+    }
+    missing = []
+    if not inventory["tools"]["tunnel-client"]:
+        missing.append("install tunnel-client (OpenAI Secure MCP Tunnel)")
+    if not inventory["env_present"]["CONTROL_PLANE_API_KEY"]:
+        missing.append("set CONTROL_PLANE_API_KEY")
+    if not inventory["env_present"]["OPENAI_TUNNEL_ID"]:
+        missing.append("set OPENAI_TUNNEL_ID")
+    if not inventory["env_present"]["PUBLIC_GROK_HOSTNAME"]:
+        missing.append("set PUBLIC_GROK_HOSTNAME (stable named tunnel host)")
+    if not inventory["env_present"]["PUBLIC_GEMINI_HOSTNAME"]:
+        missing.append("set PUBLIC_GEMINI_HOSTNAME")
+    if not inventory["env_present"]["DCP_ACCEPTANCE_LIVE_TOKEN"]:
+        missing.append("set DCP_ACCEPTANCE_LIVE_TOKEN (connector bearer)")
+    inventory["missing_for_vendor_live"] = missing
+    return inventory
+
+
+def run_two_worktree_isolation_gates() -> list[GateResult]:
+    """ACC-029: synthetic two-target isolation without vendor tunnels.
+
+    Proves connector A cannot authorize target B and ownership for A/B is distinct.
+    Does not call real ConPort/dope-memory backends.
+    """
+    results: list[GateResult] = []
+    policy_doc = {
+        "records": [
+            _fixture_policy("conn-a", "DCP_TOKEN_A", ["target-a"]),
+            _fixture_policy("conn-b", "DCP_TOKEN_B", ["target-b"]),
+        ]
+    }
+    # multi_target false with one target each
+    store = parse_connector_policy_document(policy_doc)
+    resolver = MappingSecretResolver(
+        {
+            ("environment", "env:DCP_TOKEN_A"): "token-a-secret",
+            ("environment", "env:DCP_TOKEN_B"): "token-b-secret",
+        }
+    )
+    ctx_a, d_a = authenticate_bearer(store, presented_token="token-a-secret", secret_resolver=resolver)
+    ctx_b, d_b = authenticate_bearer(store, presented_token="token-b-secret", secret_resolver=resolver)
+    if not (d_a.allowed and d_b.allowed and ctx_a and ctx_b):
+        results.append(_fail("DCP-ACC-029", "live", "failed to authenticate dual connector fixtures"))
+        return results
+
+    a_ok = authorize_target(ctx_a, "target-a")
+    a_cross = authorize_target(ctx_a, "target-b")
+    b_ok = authorize_target(ctx_b, "target-b")
+    b_cross = authorize_target(ctx_b, "target-a")
+    invented = authorize_target(ctx_a, "invented-target")
+
+    own_a = verify_ownership(
+        OwnershipEvidence(
+            family="conport",
+            expected_project_id="proj-a",
+            expected_project_root="/tmp/wt-a",
+            expected_worktree_root="/tmp/wt-a",
+            runtime_project_id="proj-a",
+            runtime_project_root="/tmp/wt-a",
+            runtime_worktree_root="/tmp/wt-a",
+            labels={
+                "dopemux.project_id": "proj-a",
+                "dopemux.service": "conport",
+                "dopemux.worktree_root": "/tmp/wt-a",
+            },
+            mounts=("/tmp/wt-a",),
+            protocol_ok=True,
+            candidate_count=1,
+        )
+    )
+    own_b_wrong = verify_ownership(
+        OwnershipEvidence(
+            family="conport",
+            expected_project_id="proj-a",
+            expected_project_root="/tmp/wt-a",
+            expected_worktree_root="/tmp/wt-a",
+            runtime_project_id="proj-b",
+            runtime_project_root="/tmp/wt-b",
+            runtime_worktree_root="/tmp/wt-b",
+            labels={
+                "dopemux.project_id": "proj-b",
+                "dopemux.service": "conport",
+                "dopemux.worktree_root": "/tmp/wt-b",
+            },
+            mounts=("/tmp/wt-b",),
+            protocol_ok=True,
+            candidate_count=1,
+        )
+    )
+
+    if (
+        a_ok.allowed
+        and b_ok.allowed
+        and not a_cross.allowed
+        and not b_cross.allowed
+        and not invented.allowed
+        and own_a.verified
+        and not own_b_wrong.verified
+    ):
+        results.append(
+            _pass(
+                "DCP-ACC-029",
+                "live",
+                "two-target connector isolation + wrong-owner ownership block (synthetic, no vendor tunnel)",
+            )
+        )
+    else:
+        results.append(_fail("DCP-ACC-029", "live", "two-target isolation matrix unexpected"))
+    return results
+
+
+def run_vendor_live_gates(providers: set[str]) -> list[GateResult]:
+    """Vendor tunnel/provider gates: preflight only unless full tooling+env present.
+
+    Never opens public tunnels or invents credentials.
+    """
+    results: list[GateResult] = []
+    inv = vendor_preflight()
+    runnable = inv["gates_runnable"]
+
+    # Always attach preflight evidence (no secrets)
+    preflight_detail = "vendor preflight: missing=" + ",".join(inv["missing_for_vendor_live"] or ["none"])
+
+    # ACC-024 ChatGPT
+    if "chatgpt" in providers or not (providers & VENDOR_PROVIDERS):
+        # if vendors requested broadly, evaluate chatgpt when listed or when any vendor listed
+        want_chatgpt = "chatgpt" in providers or bool(providers & {"chatgpt"})
+    else:
+        want_chatgpt = "chatgpt" in providers
+    # simplify: if any vendor provider listed, check each
+    if providers & VENDOR_PROVIDERS or "vendor" in providers:
+        if runnable["DCP-ACC-024_chatgpt_tunnel"] and "chatgpt" in providers:
+            results.append(
+                _not_run(
+                    "DCP-ACC-024",
+                    "live",
+                    "ChatGPT preflight OK but automated tunnel-client exercise is not auto-run; "
+                    "operator must execute tunnel-client and attach redacted doctor/export receipts. "
+                    + preflight_detail,
+                )
+            )
+        else:
+            results.append(
+                _not_run(
+                    "DCP-ACC-024",
+                    "live",
+                    "ChatGPT tunnel not runnable: need tunnel-client + CONTROL_PLANE_API_KEY + "
+                    "OPENAI_TUNNEL_ID + connector token. " + preflight_detail,
+                    tools=inv["tools"],
+                    env_present=inv["env_present"],
+                )
+            )
+
+        if runnable["DCP-ACC-025_grok_stable"] and "grok" in providers:
+            results.append(
+                _not_run(
+                    "DCP-ACC-025",
+                    "live",
+                    "Grok hostname present but stable tunnel restart acceptance is manual; "
+                    "attach redacted DNS/HTTPS + discovery receipts. " + preflight_detail,
+                )
+            )
+        else:
+            results.append(
+                _not_run(
+                    "DCP-ACC-025",
+                    "live",
+                    "Grok stable route not runnable: need PUBLIC_GROK_HOSTNAME + connector token. "
+                    + preflight_detail,
+                    env_present=inv["env_present"],
+                )
+            )
+
+        if runnable["DCP-ACC-026_gemini_transport"] and (
+            "gemini" in providers or "gemini_api" in providers
+        ):
+            results.append(
+                _not_run(
+                    "DCP-ACC-026",
+                    "live",
+                    "Gemini host present but unsupported-transport fail-closed check is manual; "
+                    "attach provider error + DCP no-call proof. " + preflight_detail,
+                )
+            )
+        else:
+            results.append(
+                _not_run(
+                    "DCP-ACC-026",
+                    "live",
+                    "Gemini transport gate not runnable: need PUBLIC_GEMINI_HOSTNAME + connector token. "
+                    + preflight_detail,
+                    env_present=inv["env_present"],
+                )
+            )
+    else:
+        for tid, label in (
+            ("DCP-ACC-024", "chatgpt"),
+            ("DCP-ACC-025", "grok"),
+            ("DCP-ACC-026", "gemini"),
+        ):
+            results.append(
+                _not_run(
+                    tid,
+                    "live",
+                    f"vendor provider '{label}' not listed; set "
+                    f"DCP_ACCEPTANCE_LIVE_PROVIDERS=local,chatgpt,grok,gemini as applicable. "
+                    + preflight_detail,
+                )
+            )
+    return results
+
+
+def run_live_gates() -> list[GateResult]:
+    """Live gates: fail closed without dual consent; local/vendor as requested."""
+    ok, reason = live_mode_authorized()
+    vendor_ids = ["DCP-ACC-024", "DCP-ACC-025", "DCP-ACC-026"]
     local_capable_ids = {
         "DCP-ACC-006",
         "DCP-ACC-013",
@@ -607,23 +857,34 @@ def run_live_gates() -> list[GateResult]:
         "DCP-ACC-027",
         "DCP-ACC-028",
     }
-    all_live_ids = sorted(local_capable_ids | set(vendor_ids) | {"DCP-ACC-007", "DCP-ACC-008", "DCP-ACC-009", "DCP-ACC-010", "DCP-ACC-016"})
+    all_live_ids = sorted(
+        local_capable_ids
+        | set(vendor_ids)
+        | {"DCP-ACC-007", "DCP-ACC-008", "DCP-ACC-009", "DCP-ACC-010", "DCP-ACC-016", "DCP-ACC-029"}
+    )
 
     if not ok:
         return [_not_run(tid, "live", f"live gate blocked: {reason}") for tid in all_live_ids]
 
     providers = set(parse_live_providers())
+    if "vendor" in providers:
+        providers |= {"chatgpt", "grok", "gemini"}
+
     results: list[GateResult] = []
     token = os.getenv(LIVE_TOKEN_ENV, "").strip()
 
+    # Local loopback suite
     if providers & LOCAL_PROVIDERS:
         try:
             results.extend(run_local_loopback_live_gates(token))
-        except Exception as exc:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover
             results.append(
-                _fail("DCP-ACC-028", "live", f"local loopback live suite crashed: {exc.__class__.__name__}")
+                _fail(
+                    "DCP-ACC-028",
+                    "live",
+                    f"local loopback live suite crashed: {exc.__class__.__name__}",
+                )
             )
-        # Mark remaining local-capable ids not produced as NOT_RUN only if missing
         produced = {r.test_id for r in results}
         for tid in sorted(local_capable_ids - produced):
             results.append(_not_run(tid, "live", "local live suite did not emit this gate"))
@@ -633,39 +894,25 @@ def run_live_gates() -> list[GateResult]:
                 _not_run(
                     tid,
                     "live",
-                    "local loopback not requested; set DCP_ACCEPTANCE_LIVE_PROVIDERS=local",
+                    "local loopback not requested; include 'local' in DCP_ACCEPTANCE_LIVE_PROVIDERS",
                 )
             )
 
-    # Vendor tunnels always require real vendor credentials/tooling — never invent.
-    for tid in vendor_ids:
-        if providers & VENDOR_PROVIDERS:
+    # Two-target synthetic isolation
+    results.extend(run_two_worktree_isolation_gates())
+
+    # Vendor preflight (never invents credentials or opens tunnels)
+    if providers & VENDOR_PROVIDERS:
+        results.extend(run_vendor_live_gates(providers))
+    else:
+        for tid in vendor_ids:
             results.append(
                 _not_run(
                     tid,
                     "live",
-                    "vendor provider authorized in env but automated tunnel/provider runner and vendor credentials "
-                    "are not available in this environment; attach redacted manual receipts",
+                    "vendor not listed; set DCP_ACCEPTANCE_LIVE_PROVIDERS=local,chatgpt,grok,gemini",
                 )
             )
-        else:
-            results.append(
-                _not_run(
-                    tid,
-                    "live",
-                    "vendor provider not listed in DCP_ACCEPTANCE_LIVE_PROVIDERS",
-                )
-            )
-
-    # Worktree isolation still needs dual backend fixtures beyond this packet's local loopback.
-    if "DCP-ACC-029" not in {r.test_id for r in results}:
-        results.append(
-            _not_run(
-                "DCP-ACC-029",
-                "live",
-                "two-worktree backend isolation requires dual synthetic backend fixtures; not auto-run here",
-            )
-        )
 
     return results
 

--- a/services/dcp-readonly-facade/tests/test_acceptance_harness.py
+++ b/services/dcp-readonly-facade/tests/test_acceptance_harness.py
@@ -66,6 +66,27 @@ def test_local_live_loopback_passes_with_synthetic_token(monkeypatch):
     # Vendor tunnel gates remain NOT_RUN without vendor secrets/runners.
     assert any(r.test_id == "DCP-ACC-024" and r.status == "NOT_RUN" for r in live)
     assert any(r.test_id == "DCP-ACC-027" and r.status == "PASS" for r in live)
+    assert any(r.test_id == "DCP-ACC-029" and r.status == "PASS" for r in live)
     # Never leak token into details
     blob = " ".join(r.detail for r in live)
     assert "synthetic-local-live-token-0017" not in blob
+
+
+def test_vendor_preflight_reports_missing_without_secrets(monkeypatch):
+    monkeypatch.delenv("CONTROL_PLANE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_TUNNEL_ID", raising=False)
+    monkeypatch.delenv("PUBLIC_GROK_HOSTNAME", raising=False)
+    inv = ACC.vendor_preflight()
+    assert inv["gates_runnable"]["DCP-ACC-024_chatgpt_tunnel"] is False
+    assert any("tunnel-client" in m or "CONTROL_PLANE" in m for m in inv["missing_for_vendor_live"])
+
+
+def test_vendor_providers_emit_not_run_with_preflight(monkeypatch):
+    monkeypatch.setenv(ACC.LIVE_CONSENT_ENV, "1")
+    monkeypatch.setenv(ACC.LIVE_TOKEN_ENV, "synthetic-vendor-track-token")
+    monkeypatch.setenv(ACC.LIVE_PROVIDER_ENV, "local,chatgpt,grok,gemini")
+    live = ACC.run_live_gates()
+    assert any(r.test_id == "DCP-ACC-024" and r.status == "NOT_RUN" for r in live)
+    assert any(r.test_id == "DCP-ACC-025" and r.status == "NOT_RUN" for r in live)
+    assert any(r.test_id == "DCP-ACC-029" and r.status == "PASS" for r in live)
+    assert "token-a-secret" not in " ".join(r.detail for r in live)

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -141,6 +141,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0016 | DCP / MCP | Multi-Provider Setup And Rollback Docs | Active | TP-DCP-MCP-RO-0015 |
 | TP-DCP-MCP-RO-0017 | DCP / MCP | Acceptance Matrix And Fail-Closed Harness | Active | TP-DCP-MCP-RO-0016 |
 | TP-DCP-MCP-RO-0018 | DCP / MCP | Exact-Head Proof Readiness Evaluator | Active | TP-DCP-MCP-RO-0017 |
+| TP-DCP-MCP-RO-0017-VENDOR | DCP / MCP | Vendor-Live Preflight And Two-Target Isolation | Active | TP-DCP-MCP-RO-0017 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.json
@@ -1,0 +1,57 @@
+{
+  "id": "TP-DCP-MCP-RO-0017-VENDOR",
+  "project": "dopemux-mvp",
+  "target": "Vendor-live residual: preflight inventory for ChatGPT/Grok/Gemini gates, synthetic ACC-029 isolation, fail-closed NOT_RUN when credentials absent; never open unrestricted public tunnels.",
+  "invariants": [
+    "Never invent vendor credentials.",
+    "Never auto-open unrestricted public tunnels.",
+    "ACC-024/025/026 remain NOT_RUN until inventory complete.",
+    "ACC-029 may PASS via synthetic two-target isolation without vendor tunnels."
+  ],
+  "depends_on": ["TP-DCP-MCP-RO-0017"],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0017",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0017-vendor-live",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "feat(dcp): vendor-live preflight and two-target isolation",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/acceptance.py",
+      "services/dcp-readonly-facade/tests/test_acceptance_harness.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/VENDOR_LIVE_PREFLIGHT.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0017-VENDOR/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_acceptance_harness.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): vendor-live preflight and two-target isolation",
+    "body": "Vendor-live residual for TP-0017: preflight inventory, ACC-029 PASS synthetic, 024-026 NOT_RUN without credentials. No public tunnels opened.",
+    "base": "main"
+  },
+  "steps": [
+    {
+      "id": "preflight",
+      "task": "Add vendor_preflight and ACC-029 synthetic isolation; document inventory.",
+      "validation": ["Harness tests pass; 029 PASS; 024-026 NOT_RUN without secrets."]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0017-VENDOR.md
@@ -1,0 +1,27 @@
+---
+id: TP-DCP-MCP-RO-0017-VENDOR
+title: Vendor-Live Preflight And Two-Target Isolation
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Vendor-live residual preflight and synthetic ACC-029 isolation for DCP multi-provider series.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0017-VENDOR
+
+## Objective
+
+Advance residual vendor-live track without inventing credentials or opening
+unrestricted public tunnels.
+
+## Outcome this packet
+
+- ACC-029 synthetic two-target isolation: **PASS**
+- ACC-024/025/026: **NOT_RUN** with explicit missing inventory
+- `release_ready`: still **false**
+
+## Required next operator inputs
+
+See `VENDOR_LIVE_PREFLIGHT.md`.


### PR DESCRIPTION
## Summary

Residual **vendor-live** track for TP-0017 (series residual option 1).

- `vendor_preflight()` inventory (tools + env presence, no secret values)
- **DCP-ACC-029 PASS** via synthetic two-target isolation (no vendor tunnel)
- **DCP-ACC-024/025/026 NOT_RUN** with explicit missing list
- `release_ready` remains **false**
- Docs: `VENDOR_LIVE_PREFLIGHT.md`

## What was *not* done (correctly)

- No OpenAI/Grok/Gemini credentials invented
- No unrestricted public `cloudflared` quick tunnel opened
- No ChatGPT `tunnel-client` exercise (`tunnel-client` absent)

## Missing for full vendor-live

- install `tunnel-client`
- `CONTROL_PLANE_API_KEY`, `OPENAI_TUNNEL_ID`
- `PUBLIC_GROK_HOSTNAME`, `PUBLIC_GEMINI_HOSTNAME`
- connector bearer in secret store

## Validation

- acceptance harness tests: 8 passed
- full facade suite: passed
- vendor-track report: 029 PASS; 024–026 NOT_RUN; `release_ready=false`

## Readiness

Not production READY. Trusted audit still SKIPPED under local-only constraints.