### PR TITLE
feat(audit): accept signed local audit attestations in the embedded-audit gate

### DIFF
--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -176,6 +176,35 @@ jobs:
           # Soft exit: hard proof enforcement is authoritative (see step comments).
           exit 0
 
+      - name: Evaluate local signed audit attestation
+        if: always() && steps.head_integrity.outputs.verified == 'true'
+        working-directory: trusted-source
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          # Fail-closed fallback for runs where no auditor CLI/provider is
+          # provisioned: accept a locally-executed audit ONLY when the PR head
+          # carries proof/pr_merge/embedded-audit/pr-<N>/PROOF.json signed by a
+          # key in the TRUSTED allowed-signers file, bound to this repo+PR, and
+          # the audited commit differs from the head by proof-dir files alone.
+          # Candidate PR code is read as git blobs only — never executed.
+          # Soft exit: a rejected/absent attestation leaves today's
+          # SKIPPED/red path unchanged; the emit + enforce steps stay the sole
+          # green/red authority.
+          set +e
+          python -m scripts.audit.local_audit_acceptance \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "${PR_NUMBER}" \
+            --head-sha "${HEAD_SHA}" \
+            --allowed-signers config/audit/embedded-audit-allowed-signers \
+            --schema schemas/proof/embedded_audit.schema.json \
+            --out ../embedded-audit-artifacts/LOCAL_AUDIT_ATTESTATION.json
+          attestation_status=$?
+          set -e
+          echo "local attestation evaluation exit=${attestation_status}"
+          exit 0
+
       - name: Emit independent embedded audit proof
         if: always() && steps.head_integrity.outputs.verified == 'true'
         working-directory: trusted-source
@@ -239,6 +268,7 @@ jobs:
             --head-sha "${HEAD_SHA}" \
             --route-json ../embedded-audit-artifacts/AUDITOR_ROUTE.json \
             --pal-output-json ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json \
+            --local-attestation-json ../embedded-audit-artifacts/LOCAL_AUDIT_ATTESTATION.json \
             --out ../embedded-audit-artifacts
 
       - name: Emit unavailable independent audit proof

--- a/config/audit/embedded-audit-allowed-signers
+++ b/config/audit/embedded-audit-allowed-signers
@@ -1,0 +1,18 @@
+# Allowed signers for locally-attested embedded-audit proofs.
+#
+# OpenSSH allowed_signers format (see ssh-keygen(1), -Y verify):
+#   <principal> [options] <key-type> <base64-key> [comment]
+#
+# This file is read ONLY from the trusted ref (main) by the embedded-audit
+# workflow — entries added on a PR branch have no effect until merged.
+# While this file contains no keys, the local-attestation path is inert and
+# the audit gate behaves exactly as before (fail-closed).
+#
+# One-time setup on the machine that runs local audits:
+#   ssh-keygen -t ed25519 -N '' -f ~/.ssh/dopemux_audit_signing \
+#     -C "dopemux embedded-audit signing"
+#   printf '%s %s\n' 'you@your-machine' "$(cut -d' ' -f1-2 ~/.ssh/dopemux_audit_signing.pub)"
+# then add the printed line below (via a reviewed PR to main).
+#
+# Example (do not uncomment; replace with your own key):
+# hue@local ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...

--- a/docs/ops/embedded-audit.md
+++ b/docs/ops/embedded-audit.md
@@ -141,6 +141,65 @@ PR-scoped gate `NOT_RUN`; regenerate the proof and re-pin it to the PR head SHA
 before the FINALIZATION gate, and record that explicitly rather than implying
 gate readiness.
 
+## Local signed attestation (CI acceptance without provider credentials)
+
+When the trusted CI job cannot execute any auditor CLI (no provider
+credentials provisioned on the runner), the `independent embedded audit` check
+can accept a **locally executed** audit through a signed, exact-head-bound
+attestation. Implemented by `scripts/audit/local_audit_acceptance.py` and the
+`Evaluate local signed audit attestation` workflow step; consumed by the proof
+emitter via `--local-attestation-json`.
+
+Acceptance is fail-closed. ALL of the following must hold:
+
+1. The PR head carries `proof/pr_merge/embedded-audit/pr-<N>/PROOF.json` and a
+   detached OpenSSH signature `PROOF.json.sig` over those exact bytes,
+   namespace `dopemux-embedded-audit`.
+2. The signature verifies against
+   `config/audit/embedded-audit-allowed-signers` **taken from the trusted ref
+   (main)** — keys added on the PR branch have no effect.
+3. The signed proof names this `repo` and `pr_number`, and its `head_sha`
+   (the audited commit) is an ancestor of the PR head where the diff between
+   them touches **only** the proof directory itself (proof-only delta: the
+   commit adding the proof is the sole change on top of the audited code).
+4. The local `embedded_audit` object is a passing verdict
+   (`PASS`/`PASS_WITH_RISKS`) and valid against
+   `schemas/proof/embedded_audit.schema.json` — including the
+   `auditor_tool`/`auditor_model` enums. (`report_path` is overridden by the
+   trusted emitter.)
+5. The least-privilege `EMBEDDED_AUDIT_TOKEN` is still present in the trusted
+   run, and the CI auditor produced **no real verdict** — a CI-executed
+   `PASS`/`PASS_WITH_RISKS`/`FAIL` always outranks the attestation.
+
+The emitted proof records the substitution explicitly:
+`provenance.audit_source = "local-signed-attestation"` plus a
+`provenance.local_attestation` object (principal, audited SHA, proof path),
+and an appended `remaining_risks` entry naming the signer. Steward summaries
+and artifacts therefore always show when a run was locally attested.
+
+**Trust model (stated plainly):** a valid signature proves that a holder of an
+allow-listed private key attests this exact code was audited locally. It is an
+operator attestation with cryptographic code-binding — not an independently
+executed CI audit. Signer changes go through reviewed PRs to main.
+
+One-time signer setup:
+
+```bash
+ssh-keygen -t ed25519 -N '' -f ~/.ssh/dopemux_audit_signing \
+  -C "dopemux embedded-audit signing"
+# add the printed public key line to config/audit/embedded-audit-allowed-signers
+# via a reviewed PR to main (instructions in that file)
+```
+
+Per-PR flow (after the local pr-merge audit writes the proof):
+
+```bash
+scripts/audit/sign_local_audit_proof.sh <pr-number>   # validates + signs
+git add proof/pr_merge/embedded-audit/pr-<N>/
+git commit -m "proof(audit): signed local embedded-audit attestation for PR <N>"
+git push   # must be the only change on top of the audited head_sha
+```
+
 ## Required Proof Object
 
 The proof object must conform to `schemas/proof/embedded_audit.schema.json` and record:

--- a/scripts/audit/local_audit_acceptance.py
+++ b/scripts/audit/local_audit_acceptance.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Fail-closed acceptance of locally-run, ssh-signed embedded-audit proofs.
+
+Purpose
+-------
+The trusted embedded-audit workflow cannot execute an auditor CLI when no
+provider credentials are provisioned. This module lets the trusted workflow
+accept an audit that was executed *locally* (pr-merge/steward flow), under a
+strict, fail-closed contract:
+
+1. The PR branch carries ``proof/pr_merge/embedded-audit/pr-<N>/PROOF.json``
+   plus a detached OpenSSH signature ``PROOF.json.sig`` over those exact bytes
+   (``ssh-keygen -Y sign -n dopemux-embedded-audit``).
+2. The signature must verify against the allowed-signers file taken from the
+   TRUSTED ref (never from the PR branch).
+3. The signed payload must name this repo and this PR number, and its
+   ``head_sha`` (the audited commit A) must be an ancestor of the enforced PR
+   head H where ``git diff A..H`` touches ONLY the proof directory itself
+   (exact-head, proof-only delta — committing the proof is the sole change
+   allowed on top of the audited code).
+4. The local ``embedded_audit`` object must be a passing verdict and must be
+   valid against the trusted ``schemas/proof/embedded_audit.schema.json``
+   (with ``report_path`` overridden by the trusted emitter downstream).
+
+Every failure produces ``accepted=false`` with explicit reasons; the caller
+(workflow) then falls through to today's SKIPPED/red behaviour. Candidate PR
+code is only ever read as git blobs — never checked out or executed.
+
+Trust model (documented, deliberate): a valid signature proves that a holder
+of an allow-listed private key attested this exact code was audited. It is an
+operator attestation, not an independent third-party audit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+SIGNATURE_NAMESPACE = "dopemux-embedded-audit"
+DEFAULT_ALLOWED_SIGNERS = Path("config/audit/embedded-audit-allowed-signers")
+DEFAULT_SCHEMA_PATH = Path("schemas/proof/embedded_audit.schema.json")
+PROOF_DIR_TEMPLATE = "proof/pr_merge/embedded-audit/pr-{pr_number}"
+PASSING_AUDIT_STATUSES = frozenset({"PASS", "PASS_WITH_RISKS"})
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# Deepen in two bounded steps; beyond this the proof commit is suspiciously far
+# from the audited commit and we fail closed rather than fetch unbounded history.
+FETCH_DEPTHS = (100, 500)
+
+
+def _run_git(repo_root: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        check=False,
+    )
+
+
+def _read_blob(repo_root: Path, rev: str, path: str) -> bytes | None:
+    result = _run_git(repo_root, "cat-file", "blob", f"{rev}:{path}")
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _object_exists(repo_root: Path, sha: str) -> bool:
+    return _run_git(repo_root, "cat-file", "-e", f"{sha}^{{commit}}").returncode == 0
+
+
+def _ensure_objects(repo_root: Path, head_sha: str, audited_sha: str) -> str | None:
+    """Fetch enough history for the ancestry/diff checks. Returns error or None."""
+    if _object_exists(repo_root, head_sha) and _object_exists(repo_root, audited_sha):
+        return None
+    for depth in FETCH_DEPTHS:
+        _run_git(
+            repo_root,
+            "fetch",
+            "--no-tags",
+            f"--depth={depth}",
+            "origin",
+            head_sha,
+        )
+        if _object_exists(repo_root, head_sha) and _object_exists(repo_root, audited_sha):
+            return None
+    return (
+        f"objects_unreachable: audited commit {audited_sha} not reachable from "
+        f"head {head_sha} within fetch depth {FETCH_DEPTHS[-1]}"
+    )
+
+
+def _is_ancestor(repo_root: Path, ancestor: str, descendant: str) -> bool:
+    return (
+        _run_git(repo_root, "merge-base", "--is-ancestor", ancestor, descendant).returncode
+        == 0
+    )
+
+
+def _changed_paths(repo_root: Path, base: str, head: str) -> list[str] | None:
+    # --no-renames: porcelain diff detects renames by default (diff.renames),
+    # and a rename's --name-only output can show only the destination path — a
+    # rename of a code file INTO the proof dir would otherwise hide the source
+    # deletion from the proof-only-delta check.
+    result = _run_git(repo_root, "diff", "--no-renames", "--name-only", base, head)
+    if result.returncode != 0:
+        return None
+    return [line for line in result.stdout.decode("utf-8", "replace").splitlines() if line]
+
+
+def _verify_signature(
+    proof_bytes: bytes,
+    signature_bytes: bytes,
+    allowed_signers: Path,
+) -> tuple[str | None, str | None]:
+    """Verify an OpenSSH detached signature. Returns (principal, error)."""
+    if not allowed_signers.is_file():
+        return None, f"allowed_signers_missing: {allowed_signers}"
+    with tempfile.TemporaryDirectory(prefix="local-audit-sig.") as tmp:
+        sig_path = Path(tmp) / "PROOF.json.sig"
+        sig_path.write_bytes(signature_bytes)
+
+        find = subprocess.run(
+            [
+                "ssh-keygen",
+                "-Y",
+                "find-principals",
+                "-s",
+                str(sig_path),
+                "-f",
+                str(allowed_signers),
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if find.returncode != 0:
+            detail = find.stderr.decode("utf-8", "replace").strip()
+            return None, f"signature_principal_not_allowed: {detail or 'no matching principal'}"
+        principals = [
+            line.strip()
+            for line in find.stdout.decode("utf-8", "replace").splitlines()
+            if line.strip()
+        ]
+        if not principals:
+            return None, "signature_principal_not_allowed: empty principal list"
+        principal = principals[0]
+
+        verify = subprocess.run(
+            [
+                "ssh-keygen",
+                "-Y",
+                "verify",
+                "-f",
+                str(allowed_signers),
+                "-I",
+                principal,
+                "-n",
+                SIGNATURE_NAMESPACE,
+                "-s",
+                str(sig_path),
+            ],
+            input=proof_bytes,
+            capture_output=True,
+            check=False,
+        )
+        if verify.returncode != 0:
+            detail = verify.stderr.decode("utf-8", "replace").strip()
+            return None, f"signature_invalid: {detail or 'verification failed'}"
+    return principal, None
+
+
+def _load_schema_enums(schema_path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return None, f"schema_unreadable: {schema_path}: {exc}"
+    if not isinstance(schema, dict):
+        return None, f"schema_malformed: {schema_path}"
+    return schema, None
+
+
+def _validate_embedded_audit(
+    embedded: Mapping[str, Any],
+    schema: Mapping[str, Any],
+) -> list[str]:
+    """Structural validation against the trusted schema (stdlib only).
+
+    ``report_path`` is intentionally NOT validated here — the trusted emitter
+    overrides it with its own canonical artifact path.
+    """
+    errors: list[str] = []
+    properties = schema.get("properties", {})
+    required = [key for key in schema.get("required", []) if key != "report_path"]
+
+    for key in required:
+        if key not in embedded:
+            errors.append(f"local_audit_missing_field: {key}")
+    if errors:
+        return errors
+
+    status = embedded.get("status")
+    status_enum = properties.get("status", {}).get("enum", [])
+    if status not in status_enum:
+        errors.append(f"local_audit_status_not_in_schema: {status!r}")
+    elif status not in PASSING_AUDIT_STATUSES:
+        errors.append(f"local_audit_not_passing: {status!r}")
+
+    tool = embedded.get("auditor_tool")
+    tool_enum = properties.get("auditor_tool", {}).get("enum", [])
+    if tool not in tool_enum:
+        errors.append(
+            f"local_audit_tool_not_in_schema: {tool!r} (allowed: {sorted(tool_enum)})"
+        )
+    model = embedded.get("auditor_model")
+    model_enum = properties.get("auditor_model", {}).get("enum", [])
+    if model not in model_enum:
+        errors.append(
+            f"local_audit_model_not_in_schema: {model!r} (allowed: {sorted(model_enum)})"
+        )
+
+    if embedded.get("required") is not True:
+        errors.append("local_audit_required_flag: embedded_audit.required must be true")
+    for list_field in ("findings", "fixes_applied", "remaining_risks"):
+        if not isinstance(embedded.get(list_field), list):
+            errors.append(f"local_audit_field_not_list: {list_field}")
+    exit_code = embedded.get("exit_code")
+    if exit_code is not None and not isinstance(exit_code, int):
+        errors.append("local_audit_exit_code_type: must be integer or null")
+    invocation = embedded.get("invocation")
+    if invocation is not None and not isinstance(invocation, str):
+        errors.append("local_audit_invocation_type: must be string or null")
+    return errors
+
+
+def evaluate_local_audit(
+    *,
+    repo_root: Path,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    allowed_signers: Path,
+    schema_path: Path,
+) -> dict[str, Any]:
+    """Evaluate a signed local audit proof for exactly this PR head.
+
+    Returns an attestation record; ``accepted`` is True only when every check
+    passed. All git access is read-only blob/commit inspection.
+    """
+    proof_dir = PROOF_DIR_TEMPLATE.format(pr_number=pr_number)
+    proof_path = f"{proof_dir}/PROOF.json"
+    signature_path = f"{proof_path}.sig"
+    attestation: dict[str, Any] = {
+        "accepted": False,
+        "reasons": [],
+        "repo": repo,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "audited_sha": None,
+        "principal": None,
+        "proof_path": proof_path,
+        "signature_namespace": SIGNATURE_NAMESPACE,
+        "embedded_audit": None,
+    }
+    reasons: list[str] = attestation["reasons"]
+
+    if not _SHA_RE.match(head_sha):
+        reasons.append(f"head_sha_malformed: {head_sha!r}")
+        return attestation
+    if not _object_exists(repo_root, head_sha):
+        _run_git(repo_root, "fetch", "--no-tags", f"--depth={FETCH_DEPTHS[0]}", "origin", head_sha)
+    if not _object_exists(repo_root, head_sha):
+        reasons.append(f"head_unreachable: {head_sha}")
+        return attestation
+
+    proof_bytes = _read_blob(repo_root, head_sha, proof_path)
+    if proof_bytes is None:
+        reasons.append(f"local_proof_absent: {proof_path} not present at PR head")
+        return attestation
+    signature_bytes = _read_blob(repo_root, head_sha, signature_path)
+    if signature_bytes is None:
+        reasons.append(f"local_signature_absent: {signature_path} not present at PR head")
+        return attestation
+
+    principal, sig_error = _verify_signature(proof_bytes, signature_bytes, allowed_signers)
+    if sig_error:
+        reasons.append(sig_error)
+        return attestation
+    attestation["principal"] = principal
+
+    try:
+        proof = json.loads(proof_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        reasons.append(f"local_proof_malformed: {exc}")
+        return attestation
+    if not isinstance(proof, dict):
+        reasons.append("local_proof_malformed: root is not an object")
+        return attestation
+
+    proof_repo = str(proof.get("repo") or "")
+    if proof_repo != repo:
+        reasons.append(f"local_proof_repo_mismatch: {proof_repo!r} expected {repo!r}")
+    try:
+        proof_pr = int(proof.get("pr_number"))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        proof_pr = None
+    if proof_pr != pr_number:
+        reasons.append(
+            f"local_proof_pr_mismatch: {proof.get('pr_number')!r} expected {pr_number}"
+        )
+
+    audited_sha = str(proof.get("head_sha") or "")
+    if not _SHA_RE.match(audited_sha):
+        reasons.append(f"local_proof_audited_sha_malformed: {audited_sha!r}")
+        return attestation
+    attestation["audited_sha"] = audited_sha
+    if reasons:
+        return attestation
+
+    fetch_error = _ensure_objects(repo_root, head_sha, audited_sha)
+    if fetch_error:
+        reasons.append(fetch_error)
+        return attestation
+    if not _is_ancestor(repo_root, audited_sha, head_sha):
+        reasons.append(
+            f"audited_sha_not_ancestor: {audited_sha} is not an ancestor of {head_sha}"
+        )
+        return attestation
+
+    changed = _changed_paths(repo_root, audited_sha, head_sha)
+    if changed is None:
+        reasons.append("delta_unavailable: git diff between audited and head failed")
+        return attestation
+    offending = [path for path in changed if not path.startswith(f"{proof_dir}/")]
+    if offending:
+        preview = ", ".join(sorted(offending)[:5])
+        reasons.append(
+            "delta_touches_code: commits after the audited SHA modify paths outside "
+            f"{proof_dir}/ ({preview})"
+        )
+        return attestation
+
+    embedded = proof.get("embedded_audit")
+    if not isinstance(embedded, dict):
+        reasons.append("local_audit_missing: embedded_audit object required")
+        return attestation
+    schema, schema_error = _load_schema_enums(schema_path)
+    if schema is None:
+        reasons.append(schema_error or f"schema_unreadable: {schema_path}")
+        return attestation
+    schema_errors = _validate_embedded_audit(embedded, schema)
+    if schema_errors:
+        reasons.extend(schema_errors)
+        return attestation
+
+    attestation["embedded_audit"] = embedded
+    attestation["accepted"] = True
+    return attestation
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify a signed local embedded-audit proof committed on a PR branch "
+            "(fail-closed; trusted-ref allowed-signers only)."
+        )
+    )
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", required=True, type=int)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--allowed-signers", type=Path, default=DEFAULT_ALLOWED_SIGNERS)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA_PATH)
+    parser.add_argument("--out", required=True, type=Path, help="Attestation JSON output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    attestation = evaluate_local_audit(
+        repo_root=args.repo_root,
+        repo=args.repo,
+        pr_number=args.pr,
+        head_sha=args.head_sha,
+        allowed_signers=args.allowed_signers,
+        schema_path=args.schema,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(attestation, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if attestation["accepted"]:
+        print(
+            f"local audit attestation ACCEPTED for PR {args.pr} "
+            f"(principal={attestation['principal']}, audited={attestation['audited_sha']})"
+        )
+        return 0
+    print(
+        "local audit attestation REJECTED: " + "; ".join(attestation["reasons"]),
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/run_embedded_audit.py
+++ b/scripts/audit/run_embedded_audit.py
@@ -170,6 +170,33 @@ def build_diagnostic_failure_proof(
     }
 
 
+def _accepted_local_attestation(
+    local_attestation: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    """Return the attestation when it is an accepted local-signed audit."""
+    if not isinstance(local_attestation, Mapping):
+        return None
+    if local_attestation.get("accepted") is not True:
+        return None
+    if not isinstance(local_attestation.get("embedded_audit"), Mapping):
+        return None
+    return local_attestation
+
+
+def _executed_ci_verdict(embedded_audit: Mapping[str, Any]) -> bool:
+    """True when the CI-run auditor produced a real verdict (incl. FAIL).
+
+    A real CI verdict — even a failing one — always outranks a local
+    attestation; the local path only fills the could-not-run gap
+    (SKIPPED / NEEDS_SUPERVISOR).
+    """
+    return str(embedded_audit.get("status") or "").upper() in {
+        "PASS",
+        "PASS_WITH_RISKS",
+        "FAIL",
+    }
+
+
 def build_embedded_audit_proof(
     *,
     packet_id: str,
@@ -182,6 +209,7 @@ def build_embedded_audit_proof(
     token_source: str,
     route_error: str | None = None,
     pal_output_error: str | None = None,
+    local_attestation: Mapping[str, Any] | None = None,
     generated_at: str | None = None,
 ) -> dict[str, Any]:
     """Build a top-level proof bundle with canonical embedded_audit object."""
@@ -230,37 +258,78 @@ def build_embedded_audit_proof(
         )
         trusted_token_status = "AVAILABLE"
 
+    executed = bool(
+        token_present
+        and not route_error
+        and not pal_output_error
+        and pal_output is not None
+    )
+
+    # Local-signed attestation fills the could-not-run gap ONLY: a real
+    # CI-executed verdict (PASS/PASS_WITH_RISKS/FAIL) always takes precedence,
+    # and the least-privilege token must still be present so only trusted runs
+    # emit executed proofs. The attestation was verified upstream by
+    # scripts/audit/local_audit_acceptance.py (signature against the trusted
+    # allowed-signers file, exact-head proof-only delta, schema-valid verdict).
+    accepted_local = _accepted_local_attestation(local_attestation)
+    local_used = bool(
+        accepted_local
+        and token_present
+        and not _executed_ci_verdict(embedded_audit)
+    )
+    audit_source = "ci-executed" if executed else "ci-unavailable"
+    if local_used and accepted_local is not None:
+        embedded_audit = dict(accepted_local["embedded_audit"])
+        embedded_audit["report_path"] = report_path
+        remaining_risks = [str(risk) for risk in embedded_audit.get("remaining_risks") or []]
+        remaining_risks.append(
+            "Audit executed locally at "
+            f"{accepted_local.get('audited_sha')} and accepted via signed "
+            f"attestation by allow-listed principal "
+            f"{accepted_local.get('principal')!r} (proof-only delta verified); "
+            "not an independently executed CI audit."
+        )
+        embedded_audit["remaining_risks"] = remaining_risks
+        executed = True
+        audit_source = "local-signed-attestation"
+
+    provenance: dict[str, Any] = {
+        "proof_author": PROOF_AUTHOR,
+        "workflow": "embedded-audit.yml",
+        "trusted_token_status": trusted_token_status,
+        "token_source": token_source,
+        "token_value_recorded": False,
+        "audit_source": audit_source,
+        "permissions": {
+            "actions": "read",
+            "checks": "read",
+            "contents": "read",
+            "pull-requests": "read",
+            "statuses": "read",
+        },
+        "engine_authored_proof": False,
+        "engine_requested_only": True,
+    }
+    if local_used and accepted_local is not None:
+        provenance["local_attestation"] = {
+            "principal": accepted_local.get("principal"),
+            "audited_sha": accepted_local.get("audited_sha"),
+            "proof_path": accepted_local.get("proof_path"),
+            "signature_namespace": accepted_local.get("signature_namespace"),
+            "signature_verified": True,
+        }
+
     return {
         "packet_id": packet_id,
         "repo": repo,
         "pr_number": int(pr_number),
         "head_sha": head_sha,
         "generated_at": generated_at or _utc_now_seconds(),
-        "executed": bool(
-            token_present
-            and not route_error
-            and not pal_output_error
-            and pal_output is not None
-        ),
+        "executed": executed,
         "mutation_performed": False,
         "github_mutation_route_added": False,
         "embedded_audit": embedded_audit,
-        "provenance": {
-            "proof_author": PROOF_AUTHOR,
-            "workflow": "embedded-audit.yml",
-            "trusted_token_status": trusted_token_status,
-            "token_source": token_source,
-            "token_value_recorded": False,
-            "permissions": {
-                "actions": "read",
-                "checks": "read",
-                "contents": "read",
-                "pull-requests": "read",
-                "statuses": "read",
-            },
-            "engine_authored_proof": False,
-            "engine_requested_only": True,
-        },
+        "provenance": provenance,
     }
 
 
@@ -290,6 +359,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--head-sha", required=True)
     parser.add_argument("--route-json", required=True, type=Path)
     parser.add_argument("--pal-output-json", type=Path)
+    parser.add_argument(
+        "--local-attestation-json",
+        type=Path,
+        help=(
+            "Optional LOCAL_AUDIT_ATTESTATION.json produced by "
+            "scripts/audit/local_audit_acceptance.py; consumed only when the "
+            "CI auditor produced no real verdict."
+        ),
+    )
     parser.add_argument("--out", required=True, type=Path)
     parser.add_argument("--generated-at")
     return parser
@@ -308,6 +386,11 @@ def run_cli(
         if args.pal_output_json
         else (None, None)
     )
+    local_attestation: dict[str, Any] | None = None
+    if args.local_attestation_json:
+        # Malformed/missing attestation degrades to None — fail-closed to the
+        # existing SKIPPED path, never an error that masks the audit result.
+        local_attestation, _ = _read_optional_json_object(args.local_attestation_json)
     proof = build_embedded_audit_proof(
         packet_id=args.packet_id,
         repo=args.repo,
@@ -319,6 +402,7 @@ def run_cli(
         token_source=TOKEN_ENV_VAR,
         route_error=route_error,
         pal_output_error=pal_output_error,
+        local_attestation=local_attestation,
         generated_at=args.generated_at,
     )
     _write_outputs(args.out, proof)

--- a/scripts/audit/sign_local_audit_proof.sh
+++ b/scripts/audit/sign_local_audit_proof.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Sign a locally-produced embedded-audit proof so the trusted embedded-audit
+# workflow can accept it (see scripts/audit/local_audit_acceptance.py).
+#
+# Usage:
+#   scripts/audit/sign_local_audit_proof.sh <pr-number> [signing-key]
+#
+# Prerequisites:
+#   - proof/pr_merge/embedded-audit/pr-<N>/PROOF.json exists, with:
+#       repo, pr_number, head_sha (the audited commit), and a PASSING,
+#       schema-valid embedded_audit object (auditor_tool/auditor_model must be
+#       values from schemas/proof/embedded_audit.schema.json).
+#   - Your PUBLIC key is listed in config/audit/embedded-audit-allowed-signers
+#     on main (one-time setup; instructions in that file).
+#
+# After signing, commit BOTH files to the PR branch. That commit must be the
+# only change on top of the audited head_sha (proof-only delta), or CI rejects.
+#
+set -euo pipefail
+
+PR_NUMBER="${1:?usage: sign_local_audit_proof.sh <pr-number> [signing-key]}"
+KEY_PATH="${2:-$HOME/.ssh/dopemux_audit_signing}"
+NAMESPACE="dopemux-embedded-audit"
+PROOF_DIR="proof/pr_merge/embedded-audit/pr-${PR_NUMBER}"
+PROOF_FILE="${PROOF_DIR}/PROOF.json"
+
+if [ ! -f "$PROOF_FILE" ]; then
+    echo "error: $PROOF_FILE not found (run the local audit flow first)" >&2
+    exit 1
+fi
+if [ ! -f "$KEY_PATH" ]; then
+    echo "error: signing key $KEY_PATH not found" >&2
+    echo "one-time setup: ssh-keygen -t ed25519 -N '' -f $KEY_PATH" >&2
+    exit 1
+fi
+
+# Pre-flight the proof shape locally so rejections surface here, not in CI.
+python3 - "$PROOF_FILE" "$PR_NUMBER" <<'PY'
+import json, re, sys
+from pathlib import Path
+
+proof_file, pr_number = Path(sys.argv[1]), int(sys.argv[2])
+proof = json.loads(proof_file.read_text(encoding="utf-8"))
+errors = []
+if int(proof.get("pr_number") or 0) != pr_number:
+    errors.append(f"pr_number={proof.get('pr_number')!r} != {pr_number}")
+if not proof.get("repo"):
+    errors.append("repo missing")
+if not re.match(r"^[0-9a-f]{40}$", str(proof.get("head_sha") or "")):
+    errors.append("head_sha missing or not a full 40-char sha")
+embedded = proof.get("embedded_audit") or {}
+if embedded.get("status") not in ("PASS", "PASS_WITH_RISKS"):
+    errors.append(f"embedded_audit.status={embedded.get('status')!r} is not passing")
+schema_path = Path("schemas/proof/embedded_audit.schema.json")
+if schema_path.is_file():
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    props = schema.get("properties", {})
+    for field in ("auditor_tool", "auditor_model"):
+        enum = props.get(field, {}).get("enum", [])
+        if embedded.get(field) not in enum:
+            errors.append(
+                f"embedded_audit.{field}={embedded.get(field)!r} not in schema enum {enum}"
+            )
+if errors:
+    print("proof will be REJECTED by CI:", file=sys.stderr)
+    for err in errors:
+        print(f"  - {err}", file=sys.stderr)
+    sys.exit(1)
+print(f"proof shape OK (audited head {proof['head_sha']})")
+PY
+
+ssh-keygen -Y sign -f "$KEY_PATH" -n "$NAMESPACE" "$PROOF_FILE"
+echo "signed: ${PROOF_FILE}.sig"
+echo
+echo "Next steps:"
+echo "  git add ${PROOF_DIR}/"
+echo "  git commit -m 'proof(audit): signed local embedded-audit attestation for PR ${PR_NUMBER}'"
+echo "  git push"
+echo "(that commit must be the only change on top of the audited head_sha)"

--- a/tests/audit/test_local_audit_acceptance.py
+++ b/tests/audit/test_local_audit_acceptance.py
@@ -1,0 +1,407 @@
+"""Tests for fail-closed acceptance of locally-signed embedded-audit proofs."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import jsonschema
+
+from scripts.audit.local_audit_acceptance import (
+    SIGNATURE_NAMESPACE,
+    evaluate_local_audit,
+)
+from scripts.audit.run_embedded_audit import (
+    build_embedded_audit_proof,
+    enforce_independent_audit_proof,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "proof" / "embedded_audit.schema.json"
+REPO = "DDD-Enterprises/dopemux-mvp"
+PR_NUMBER = 4242
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "embedded-audit.yml"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _local_embedded_audit(status: str = "PASS", tool: str = "pal-mcp-clink") -> dict:
+    return {
+        "required": True,
+        "status": status,
+        "auditor_tool": tool,
+        "auditor_model": "sonnet",
+        "invocation": "local pr-merge audit via PAL clink",
+        "exit_code": 0,
+        "report_path": f"proof/pr_merge/embedded-audit/pr-{PR_NUMBER}/AUDITOR_REPORT.md",
+        "findings": [],
+        "fixes_applied": [],
+        "remaining_risks": [],
+        "skip_reason": None,
+    }
+
+
+class LocalAuditFixture:
+    """Temp git repo with an audited commit, a signed proof commit, and keys."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.repo = tmp_path / "repo"
+        self.repo.mkdir()
+        _git(self.repo, "init", "--quiet", "--initial-branch=main")
+        _git(self.repo, "config", "user.email", "tester@example.invalid")
+        _git(self.repo, "config", "user.name", "Tester")
+
+        (self.repo / "app.py").write_text("VALUE = 1\n", encoding="utf-8")
+        _git(self.repo, "add", "app.py")
+        _git(self.repo, "commit", "--quiet", "-m", "code under audit")
+        self.audited_sha = _git(self.repo, "rev-parse", "HEAD")
+
+        self.key = tmp_path / "signing_key"
+        subprocess.run(
+            ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(self.key)],
+            check=True,
+            capture_output=True,
+        )
+        pub = (tmp_path / "signing_key.pub").read_text(encoding="utf-8").split()
+        self.allowed_signers = tmp_path / "allowed_signers"
+        self.allowed_signers.write_text(
+            f"tester@example {pub[0]} {pub[1]}\n", encoding="utf-8"
+        )
+
+        self.proof_dir = self.repo / f"proof/pr_merge/embedded-audit/pr-{PR_NUMBER}"
+
+    def write_and_sign_proof(
+        self,
+        *,
+        embedded: dict | None = None,
+        pr_number: int = PR_NUMBER,
+        audited_sha: str | None = None,
+        namespace: str = SIGNATURE_NAMESPACE,
+        key: Path | None = None,
+        tamper_after_signing: bool = False,
+    ) -> None:
+        self.proof_dir.mkdir(parents=True, exist_ok=True)
+        proof = {
+            "packet_id": f"PR-MERGE-STEWARD-{pr_number}",
+            "repo": REPO,
+            "pr_number": pr_number,
+            "head_sha": audited_sha or self.audited_sha,
+            "generated_at": "2026-07-16T00:00:00Z",
+            "executed": True,
+            "mutation_performed": False,
+            "github_mutation_route_added": False,
+            "embedded_audit": embedded or _local_embedded_audit(),
+        }
+        proof_file = self.proof_dir / "PROOF.json"
+        proof_file.write_text(
+            json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        subprocess.run(
+            [
+                "ssh-keygen",
+                "-Y",
+                "sign",
+                "-f",
+                str(key or self.key),
+                "-n",
+                namespace,
+                str(proof_file),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        if tamper_after_signing:
+            proof["generated_at"] = "2026-07-16T00:00:01Z"
+            proof_file.write_text(
+                json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        _git(self.repo, "add", str(self.proof_dir.relative_to(self.repo)))
+        _git(self.repo, "commit", "--quiet", "-m", "proof(audit): signed attestation")
+
+    def head(self) -> str:
+        return _git(self.repo, "rev-parse", "HEAD")
+
+    def evaluate(self, **overrides) -> dict:
+        kwargs = dict(
+            repo_root=self.repo,
+            repo=REPO,
+            pr_number=PR_NUMBER,
+            head_sha=self.head(),
+            allowed_signers=self.allowed_signers,
+            schema_path=SCHEMA_PATH,
+        )
+        kwargs.update(overrides)
+        return evaluate_local_audit(**kwargs)
+
+
+def test_accepts_signed_proof_only_delta(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof()
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is True, attestation["reasons"]
+    assert attestation["principal"] == "tester@example"
+    assert attestation["audited_sha"] == fixture.audited_sha
+    assert attestation["embedded_audit"]["status"] == "PASS"
+
+
+def test_rejects_tampered_proof(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof(tamper_after_signing=True)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("signature_invalid") for r in attestation["reasons"])
+
+
+def test_rejects_signer_not_in_allowed_signers(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    rogue = tmp_path / "rogue_key"
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(rogue)],
+        check=True,
+        capture_output=True,
+    )
+    fixture.write_and_sign_proof(key=rogue)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(
+        r.startswith("signature_principal_not_allowed") for r in attestation["reasons"]
+    )
+
+
+def test_rejects_wrong_namespace(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof(namespace="file")
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("signature_invalid") for r in attestation["reasons"])
+
+
+def test_rejects_missing_allowed_signers_file(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof()
+    attestation = fixture.evaluate(allowed_signers=tmp_path / "missing_signers")
+    assert attestation["accepted"] is False
+    assert any(r.startswith("allowed_signers_missing") for r in attestation["reasons"])
+
+
+def test_rejects_absent_proof(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("local_proof_absent") for r in attestation["reasons"])
+
+
+def test_rejects_delta_touching_code(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof()
+    (fixture.repo / "app.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(fixture.repo, "add", "app.py")
+    _git(fixture.repo, "commit", "--quiet", "-m", "sneak in code after audit")
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("delta_touches_code") for r in attestation["reasons"])
+
+
+def test_rejects_rename_smuggled_into_proof_dir(tmp_path: Path) -> None:
+    """A rename whose destination is inside the proof dir must still be caught.
+
+    With default rename detection, --name-only can list only the destination
+    path — hiding the source deletion. --no-renames closes that hole.
+    """
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof()
+    _git(fixture.repo, "-c", "diff.renames=true", "mv", "app.py",
+         str(fixture.proof_dir.relative_to(fixture.repo) / "app.py"))
+    _git(fixture.repo, "commit", "--quiet", "-m", "rename code into proof dir")
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("delta_touches_code") for r in attestation["reasons"])
+
+
+def test_rejects_non_ancestor_audited_sha(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    original_audited = fixture.audited_sha
+    # Rewrite history so the audited commit is no longer an ancestor of head,
+    # while its object remains present in the repository.
+    (fixture.repo / "app.py").write_text("VALUE = 99\n", encoding="utf-8")
+    _git(fixture.repo, "add", "app.py")
+    _git(fixture.repo, "commit", "--quiet", "--amend", "-m", "rewritten history")
+    fixture.write_and_sign_proof(audited_sha=original_audited)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(
+        r.startswith(("audited_sha_not_ancestor", "objects_unreachable"))
+        for r in attestation["reasons"]
+    )
+
+
+def test_rejects_pr_number_mismatch(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof(pr_number=PR_NUMBER + 1)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("local_proof_pr_mismatch") for r in attestation["reasons"])
+
+
+def test_rejects_non_passing_local_status(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    failing = _local_embedded_audit(status="FAIL")
+    failing["exit_code"] = 1
+    fixture.write_and_sign_proof(embedded=failing)
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(r.startswith("local_audit_not_passing") for r in attestation["reasons"])
+
+
+def test_rejects_auditor_tool_outside_schema_enum(tmp_path: Path) -> None:
+    fixture = LocalAuditFixture(tmp_path)
+    fixture.write_and_sign_proof(
+        embedded=_local_embedded_audit(tool="human_integrator")
+    )
+    attestation = fixture.evaluate()
+    assert attestation["accepted"] is False
+    assert any(
+        r.startswith("local_audit_tool_not_in_schema") for r in attestation["reasons"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Emitter integration: attestation feeding build_embedded_audit_proof
+# ---------------------------------------------------------------------------
+
+
+def _route() -> dict:
+    return {
+        "tool": "pal-mcp-clink",
+        "underlying_cli": "claude",
+        "clink_client_name": "claude-audit",
+        "audit_safe_config_proven": True,
+        "clink_mutation_flags_detected": [],
+        "invocation_template": "pal-clink --client claude-audit --role codereviewer",
+    }
+
+
+def _accepted_attestation() -> dict:
+    return {
+        "accepted": True,
+        "reasons": [],
+        "repo": REPO,
+        "pr_number": PR_NUMBER,
+        "head_sha": "b" * 40,
+        "audited_sha": "a" * 40,
+        "principal": "tester@example",
+        "proof_path": f"proof/pr_merge/embedded-audit/pr-{PR_NUMBER}/PROOF.json",
+        "signature_namespace": SIGNATURE_NAMESPACE,
+        "embedded_audit": _local_embedded_audit(),
+    }
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _build(pal_output: dict | None, attestation: dict | None, token: bool = True) -> dict:
+    return build_embedded_audit_proof(
+        packet_id="TP-DMX-AUDIT-CI-PROVENANCE-104",
+        repo=REPO,
+        pr_number=PR_NUMBER,
+        head_sha="b" * 40,
+        route=_route(),
+        pal_output=pal_output,
+        token_present=token,
+        token_source="EMBEDDED_AUDIT_TOKEN",
+        local_attestation=attestation,
+    )
+
+
+def test_local_attestation_fills_ci_gap_and_passes_enforcement() -> None:
+    error_output = {"status": "error", "content": "", "risks": ["command not found"]}
+    proof = _build(error_output, _accepted_attestation())
+
+    assert proof["executed"] is True
+    embedded = proof["embedded_audit"]
+    assert embedded["status"] == "PASS"
+    assert embedded["report_path"] == (
+        "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
+    )
+    assert any("signed" in risk for risk in embedded["remaining_risks"])
+    provenance = proof["provenance"]
+    assert provenance["audit_source"] == "local-signed-attestation"
+    assert provenance["local_attestation"]["principal"] == "tester@example"
+    assert provenance["local_attestation"]["signature_verified"] is True
+
+    jsonschema.Draft7Validator(_schema()).validate(embedded)
+    enforce_independent_audit_proof(
+        proof,
+        expected_pr=PR_NUMBER,
+        expected_head_sha="b" * 40,
+        expected_repo=REPO,
+    )
+
+
+def test_ci_fail_verdict_outranks_local_attestation() -> None:
+    fail_output = {"status": "success", "verdict": "FAIL", "findings": [], "risks": []}
+    proof = _build(fail_output, _accepted_attestation())
+    assert proof["embedded_audit"]["status"] == "FAIL"
+    assert proof["provenance"]["audit_source"] == "ci-executed"
+    assert "local_attestation" not in proof["provenance"]
+
+
+def test_ci_pass_verdict_outranks_local_attestation() -> None:
+    pass_output = {"status": "success", "verdict": "PASS", "findings": [], "risks": []}
+    proof = _build(pass_output, _accepted_attestation())
+    assert proof["embedded_audit"]["status"] == "PASS"
+    assert proof["provenance"]["audit_source"] == "ci-executed"
+    assert "local_attestation" not in proof["provenance"]
+
+
+def test_local_attestation_requires_trusted_token() -> None:
+    error_output = {"status": "error", "content": "", "risks": []}
+    proof = _build(error_output, _accepted_attestation(), token=False)
+    assert proof["executed"] is False
+    assert proof["embedded_audit"]["status"] == "SKIPPED"
+    assert "local_attestation" not in proof["provenance"]
+
+
+def test_rejected_attestation_leaves_supervisor_path_unchanged() -> None:
+    error_output = {"status": "error", "content": "", "risks": []}
+    rejected = _accepted_attestation()
+    rejected["accepted"] = False
+    proof = _build(error_output, rejected)
+    assert proof["embedded_audit"]["status"] == "NEEDS_SUPERVISOR"
+    assert proof["provenance"]["audit_source"] == "ci-executed"
+    assert "local_attestation" not in proof["provenance"]
+
+
+# ---------------------------------------------------------------------------
+# Workflow shape
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_evaluates_attestation_from_trusted_source() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "Evaluate local signed audit attestation" in text
+    assert "python -m scripts.audit.local_audit_acceptance" in text
+    assert "--allowed-signers config/audit/embedded-audit-allowed-signers" in text
+    assert (
+        "--local-attestation-json ../embedded-audit-artifacts/LOCAL_AUDIT_ATTESTATION.json"
+        in text
+    )
+
+
+def test_allowed_signers_file_ships_without_keys() -> None:
+    signers = ROOT / "config" / "audit" / "embedded-audit-allowed-signers"
+    lines = [
+        line.strip()
+        for line in signers.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    assert lines == [], "allowed-signers must ship empty (feature inert) in this PR"


### PR DESCRIPTION
## Why

The `independent embedded audit` check has failed on **every recent PR** (last 10 runs uniformly red): the runner has no auditor CLI (`command 'claude' not found on PATH`), the workflow installs none, and no provider credentials will be provisioned soon. Meanwhile the real audits happen in the local pr-merge flow — whose proofs CI never reads. This PR gives the fail-closed gate a way to accept those local audits **without any provider keys**, per operator direction.

## Mechanism (fail-closed at every step)

A new trusted-workflow step accepts a locally executed audit only when ALL of the following hold:

1. The PR head carries `proof/pr_merge/embedded-audit/pr-<N>/PROOF.json` plus a detached **OpenSSH signature** over those exact bytes (`ssh-keygen -Y sign`, namespace `dopemux-embedded-audit`).
2. The signature verifies against `config/audit/embedded-audit-allowed-signers` **read from the trusted ref (main)** — keys added on a PR branch have no effect.
3. The signed payload names this repo and this PR number, and its audited commit is an **ancestor of the PR head whose diff touches only the proof directory** (exact-head, proof-only delta — committing the proof is the sole change allowed on top of the audited code). `--no-renames` closes a rename-into-proof-dir smuggle found during security review.
4. The local `embedded_audit` is a **passing, schema-valid** verdict (enums enforced from `schemas/proof/embedded_audit.schema.json`).
5. The least-privilege `EMBEDDED_AUDIT_TOKEN` is present, and the CI auditor produced **no real verdict** — a CI-executed PASS/PASS_WITH_RISKS/**FAIL always outranks** the attestation (composes cleanly with #1058 if runner provisioning lands later).

Candidate PR code is only ever read as git blobs (`git cat-file blob`), never checked out or executed — same boundary as the existing workflow. Enforcement and PR Steward are **unchanged** and remain the sole green/red authority; every rejection path degrades to today's SKIPPED/red.

The emitted proof is honest about origin: `provenance.audit_source = "local-signed-attestation"`, a `local_attestation` object (principal, audited SHA, proof path), and an appended `remaining_risks` note naming the signer.

## Trust model, stated plainly

A valid signature proves a holder of an allow-listed private key attests that exactly this code was audited locally. That is an **operator attestation with cryptographic code-binding — not an independently executed CI audit**. Signer list changes go through reviewed PRs to main. This is documented in `docs/ops/embedded-audit.md`.

## Activation (one-time, after merge)

```bash
ssh-keygen -t ed25519 -N '' -f ~/.ssh/dopemux_audit_signing -C "dopemux embedded-audit signing"
# add the public key line to config/audit/embedded-audit-allowed-signers via a PR to main
```
Per-PR: run the local audit, then `scripts/audit/sign_local_audit_proof.sh <pr-number>`, commit the proof dir, push. The signers file ships **empty**, so this PR changes zero behavior until a key is added.

## Bootstrap note

Like #1058, the workflow executes trusted-source (main) code — the mechanism activates only after merge, and **this PR's own embedded-audit check stays red by design**.

## Validation

- **PASS**: 19 new tests (real `ssh-keygen` sign/verify/tamper/rogue-key/wrong-namespace; temp-git ancestry, history-rewrite, code-delta and rename-smuggle rejections; emitter priority matrix incl. CI-FAIL-outranks-local; enforcement pass-through; workflow shape; empty-signers assertion) · full `tests/audit` + `tests/auditor_router`: **207 passed** · workflow YAML parse · `ruff` clean on new files.
- **Security review**: PAL codereview (internal steps) — one HIGH found and fixed in-review (rename smuggle); external-model leg NOT_RUN (provider 401 — the very constraint this PR addresses).
- **NOT_RUN**: live workflow run with a real signed proof (requires merge + signer key; suggest first exercising it on PR #1062).

## Residual risks (accepted, documented)

Operator-attestation trust model (key holder can attest work they merged); bounded fetch-depth can reject proofs unusually far from head (fail-closed); base-retarget after attestation is not re-audited (parity with CI-executed audit semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)