### PR TITLE
feat(audit): register hue@local public signing key

### DIFF
--- a/.claude/claude_config.json
+++ b/.claude/claude_config.json
@@ -10,14 +10,14 @@
         "DOPEMUX_INSTANCE_ID",
         "-e",
         "DOPEMUX_WORKSPACE_ID",
-        "mcp-conport_claude/tp-dmx-orch-followup-packets",
+        "mcp-conport_feat/register-audit-signing-key",
         "uvx",
         "--from",
         "context-portal-mcp",
         "conport-mcp"
       ],
       "env": {
-        "DOPEMUX_INSTANCE_ID": "claude/tp-dmx-orch-followup-packets",
+        "DOPEMUX_INSTANCE_ID": "feat/register-audit-signing-key",
         "DOPEMUX_WORKSPACE_ID": "/Users/hue/code/dopemux-mvp"
       }
     },

--- a/config/audit/embedded-audit-allowed-signers
+++ b/config/audit/embedded-audit-allowed-signers
@@ -16,3 +16,6 @@
 #
 # Example (do not uncomment; replace with your own key):
 # hue@local ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+
+hue@local ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOeP53q5HXeQupjRvDhE7Y/RTU2rEhTZJVyXFCAbOFHW
+


### PR DESCRIPTION
Registers the public key generated locally at ~/.ssh/dopemux_audit_signing.pub to enable signing local audit proofs.